### PR TITLE
Fix SHiFT auth via Gearbox website; add v1/v2 code sources + Borderlands 4 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        platform: [ubuntu-24.04, windows-2025, macos-15]
+        platform: [ubuntu-26.04, windows-2025, macos-26]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,6 +38,7 @@ jobs:
             golang.org:443
             proxy.golang.org:443
             pypi.org:443
+            storage.googleapis.com:443
             zrdfepirv2blaprdstr01a.blob.core.windows.net:443
           
       - name: Checkout Code

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,6 +39,7 @@ jobs:
             proxy.golang.org:443
             pypi.org:443
             storage.googleapis.com:443
+            sum.golang.org:443
             zrdfepirv2blaprdstr01a.blob.core.windows.net:443
           
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.21.x
+  GO_VERSION: 1.26.x
 
 permissions: read-all
 
@@ -15,7 +15,7 @@ jobs:
     name: Release
     strategy:
       matrix:
-        platform: [ubuntu-24.04]
+        platform: [ubuntu-26.04]
     permissions:
       id-token: write
       contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ builds:
       - 6
       - 7
     goamd64:
-      - v3
+      - v1
     ignore:
       - goos: linux
         goarch: ppc64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ release:
     name: bl3auto
 
 snapshot:
-  name_template: SNAPSHOT-{{ .Commit }}
+  version_template: SNAPSHOT-{{ .Commit }}
   
 #gomod:
 #  proxy: true
@@ -73,14 +73,15 @@ builds:
       - -s -w 
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     #replacements:
     #  darwin: macos
-    name_template: "{{ .ConventionalFileName }}"
+    # .ConventionalFileName was removed in goreleaser v2; use the v2 default pattern.
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     files:
       - LICENSE
       - README.md
@@ -100,7 +101,7 @@ nfpms:
   -
     id: bl3auto-nfpms
     package_name: bl3auto
-    file_name_template: "{{ .ConventionalFileName }}"
+    file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     homepage: "https://github.com/jauderho/bl3auto"
     maintainer: "Jauder Ho <jauderho@users.noreply.github.com>"
     description: "Borderlands and Wonderlands Bulk SHiFT Code Redemption System"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * The redeemed-codes cache is now a versioned format (`{version, lastRun, codes}`).
   Old bare-map files are still read, and any normal run upgrades the file in place
   and stamps `lastRun`.
+* `--migrate`: a standalone, login-free command to upgrade the redeemed-codes cache
+  file in place to the current version (`-e` selects the per-account cache). Useful
+  for explicitly converting an old file without a redemption run.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ project adheres to [Semantic Versioning](https://semver.org/).
   compiled binary works without `--config` or network access. The published
   remote config is still preferred when reachable and compatible (for hot-fixes);
   an unreachable or older-schema remote config falls back to the embedded one.
+* `--rampup`: a cautious mode for a first run or after a long gap. It paces requests
+  much more conservatively, backs off after 5 consecutive non-200 code-query
+  responses (SHiFT soft-rate-limits with 302s), and stops cleanly after 20 in a row
+  (likely shadowban) with progress saved.
+* First-run / long-gap warning: when no redeemed-codes cache exists or the last run
+  was over ~6 months ago, the tool recommends re-running with `--rampup`.
+* The redeemed-codes cache is now a versioned format (`{version, lastRun, codes}`).
+  Old bare-map files are still read, and any normal run upgrades the file in place
+  and stamps `lastRun`.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * The cache now lives in a local `codes/` directory when one exists in the working
   directory (the same path the Docker image mounts), so a native run from the project
   directory shares the cache instead of using the per-user OS config dir.
+* Crash- and Ctrl-C-safe progress: a SIGINT/SIGTERM stops the run cleanly between codes
+  with progress saved, and the cache is also checkpointed periodically mid-run so a hard
+  crash loses at most a handful of redemptions instead of the whole run.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## v2.3.0 - 2026-06-16
+### Changed
+* Fixed authentication after Gearbox retired the `api.2k.com` Borderlands API.
+  Login and redemption now use the Gearbox SHiFT website
+  (`shift.gearboxsoftware.com`): CSRF login, then per-service redemption forms
+  with async status polling.
+### Added
+* Borderlands 4 SHiFT code support.
+* Two code-list formats with dedicated parsers: v2
+  (ugoogalizer/mentalmars `shiftcodes.json`, default) and v1 (orcicorn
+  `index.json`). Redemption uses v2 and falls back to v1 if v2 is unavailable.
+* New flags: `--v1`, `--v2`, `--platform`, `--config`, `--dryrun`, `-v/--verbose`,
+  and a documented `--help`.
+* `--allow-inactive` now includes codes flagged as expired in the v2 source.
+
 ## v2.2.13 - 2022-01-18
 ### Added
 * Use goreleaser to build & release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Codes already redeemed on every linked platform are marked complete and skipped
   without a query on later runs, cutting request volume. `--refresh` re-queries those
   codes to pick up a platform linked since (expired codes stay skipped regardless).
+* `--game` / `--skip-game`: per-run, case-insensitive substring filters to redeem only
+  (or skip) certain games. Filtered-out codes are never queried, so this is the one
+  filter that cuts query volume. `--refresh` ignores them for a full re-scan.
+* The consecutive non-200 backoff and graceful stop now apply to **every** bulk run,
+  not just `--rampup` (SHiFT soft-rate-limits with 302s); `--rampup` still adds slower
+  request pacing on top.
+* Before a bulk run, the platforms your account can redeem on (derived from the cache)
+  are shown, and verbose mode prints the game each code is for.
 * The cache now lives in a local `codes/` directory when one exists in the working
   directory (the same path the Docker image mounts), so a native run from the project
   directory shares the cache instead of using the per-user OS config dir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * New flags: `--v1`, `--v2`, `--platform`, `--config`, `--dryrun`, `-v/--verbose`,
   and a documented `--help`.
 * `--allow-inactive` now includes codes flagged as expired in the v2 source.
+* Rate-limit handling for bulk redemption: requests are paced and the tool backs
+  off (and stops cleanly, saving progress) on HTTP 429/503 instead of hammering.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ project adheres to [Semantic Versioning](https://semver.org/).
   spacing now self-tunes — it widens multiplicatively on each non-200 code query (SHiFT's
   throttle signal) and narrows again after a clean streak, converging on the fastest rate
   SHiFT tolerates without tripping the rate limit. `-v` prints the interval as it adapts.
+* Rate-limit backoff now honours a server `Retry-After` header (429/503 and 302) instead
+  of always guessing an exponential wait.
+* A query redirect to the sign-in page is now recognised as a lost session rather than a
+  throttle: the run stops immediately with a "session expired" message instead of backing
+  off pointlessly and counting toward the shadowban stop.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * `--migrate`: a standalone, login-free command to upgrade the redeemed-codes cache
   file in place to the current version (`-e` selects the per-account cache). Useful
   for explicitly converting an old file without a redemption run.
+* `--count <n>`: stop and save after `n` successful redemptions (0 = no limit).
+  Handy with `--rampup` to cap how much a single run attempts.
+* Expired codes are now recorded in the cache (terminal state) and skipped entirely
+  on later runs — no repeated query or redemption attempt.
+* The cache now lives in a local `codes/` directory when one exists in the working
+  directory (the same path the Docker image mounts), so a native run from the project
+  directory shares the cache instead of using the per-user OS config dir.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * `--allow-inactive` now includes codes flagged as expired in the v2 source.
 * Rate-limit handling for bulk redemption: requests are paced and the tool backs
   off (and stops cleanly, saving progress) on HTTP 429/503 instead of hammering.
+* The runtime config is now embedded in the binary as a fallback, so a freshly
+  compiled binary works without `--config` or network access. The published
+  remote config is still preferred when reachable and compatible (for hot-fixes);
+  an unreachable or older-schema remote config falls back to the embedded one.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
   Handy with `--rampup` to cap how much a single run attempts.
 * Expired codes are now recorded in the cache (terminal state) and skipped entirely
   on later runs — no repeated query or redemption attempt.
+* Codes already redeemed on every linked platform are marked complete and skipped
+  without a query on later runs, cutting request volume. `--refresh` re-queries those
+  codes to pick up a platform linked since (expired codes stay skipped regardless).
 * The cache now lives in a local `codes/` directory when one exists in the working
   directory (the same path the Docker image mounts), so a native run from the project
   directory shares the cache instead of using the per-user OS config dir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Crash- and Ctrl-C-safe progress: a SIGINT/SIGTERM stops the run cleanly between codes
   with progress saved, and the cache is also checkpointed periodically mid-run so a hard
   crash loses at most a handful of redemptions instead of the whole run.
+* Adaptive (AIMD) request throttle on bulk runs: instead of a fixed pace, the request
+  spacing now self-tunes — it widens multiplicatively on each non-200 code query (SHiFT's
+  throttle signal) and narrows again after a clean streak, converging on the fastest rate
+  SHiFT tolerates without tripping the rate limit. `-v` prints the interval as it adapts.
 
 ## v2.2.13 - 2022-01-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run it with `--help` to view command line args that are supported.
 | `--config <path>` | Use a local `config.json` instead of the published remote config |
 | `--dryrun` | Discover and match codes but do not redeem (no side effects) |
 | `--rampup` | Cautious mode for a first run or after a long gap: paces requests, backs off after 5 consecutive non-200 responses, and stops cleanly after 20 (likely rate-limit/shadowban) |
+| `--count <n>` | Stop and save after `n` successful redemptions (`0` = no limit) |
 | `--migrate` | Upgrade the redeemed-codes cache file in place to the current version and exit (no login; `-e` selects the per-account cache) |
 | `-v`, `--verbose` | Verbose step-level logging to stderr |
 
@@ -66,6 +67,18 @@ source and falls back to the original (v1) source only if v2 is unavailable:
 - **v1** — [jauderho/shift-codes](https://github.com/jauderho/shift-codes) (orcicorn `index.json`)
 
 Use `--v1` or `--v2` to force a single source.
+
+#### Redeemed-codes cache
+
+bl3auto remembers what it has already redeemed (and which codes are expired) in a
+per-account JSON file so it doesn't reattempt them. If a `codes/` directory exists in
+the working directory, that file is stored there — the same path the Docker image
+mounts its volume onto — so a native run from the project directory shares the cache
+with Docker. Otherwise it falls back to the per-user OS config directory
+(e.g. `~/Library/Application Support/bl3auto/bl3auto` on macOS,
+`~/.config/bl3auto/bl3auto` on Linux). Run `mkdir codes` before running natively if
+you want the cache kept alongside the project. Use `--migrate` to upgrade an existing
+cache file to the current format.
 
 ### Installing
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Run it with `--help` to view command line args that are supported.
 | `--v1` | Force the original orcicorn code source |
 | `--v2` | Force the newer ugoogalizer/mentalmars code source |
 | `--platform <list>` | Comma-separated services to redeem on (`steam,epic,psn,xboxlive,nintendo,stadia`); default: all offered |
+| `--game <list>` | Only redeem these games (case-insensitive substring, e.g. `"borderlands 3,wonderlands"`); default: all |
+| `--skip-game <list>` | Skip these games (case-insensitive substring, e.g. `"borderlands 4"`) |
 | `--config <path>` | Use a local `config.json` instead of the published remote config |
 | `--dryrun` | Discover and match codes but do not redeem (no side effects) |
 | `--rampup` | Cautious mode for a first run or after a long gap: paces requests, backs off after 5 consecutive non-200 responses, and stops cleanly after 20 (likely rate-limit/shadowban) |
@@ -58,6 +60,17 @@ once per linked platform (e.g. Steam *and* Epic). To cover more platforms (PSN, 
 Nintendo, Stadia), link them once at
 [shift.gearboxsoftware.com](https://shift.gearboxsoftware.com) and bl3auto will pick
 them up automatically. Use `--platform` to narrow redemption to a subset of services.
+Before a bulk run, bl3auto prints the platforms your account can redeem on (from the
+cache) so you can confirm your account is linked as you expect.
+
+#### Skipping games you don't want
+
+SHiFT redemption isn't gated by game ownership — a code for a game you don't own still
+redeems and the reward waits until you play. If you'd rather not spend requests on a
+game (e.g. one you haven't bought yet), use `--skip-game "borderlands 4"` or restrict
+with `--game "borderlands 3,wonderlands"`. Unlike `--platform`, the game filter drops
+codes **before** they're queried, so it's the one filter that actually reduces request
+volume. It's per-run (not remembered); `--refresh` ignores it for a full re-scan.
 
 #### Code sources
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,22 @@ Run it with `--help` to view command line args that are supported.
 | `--platform <list>` | Comma-separated services to redeem on (`steam,epic,psn,xboxlive,nintendo,stadia`); default: all offered |
 | `--config <path>` | Use a local `config.json` instead of the published remote config |
 | `--dryrun` | Discover and match codes but do not redeem (no side effects) |
+| `--rampup` | Cautious mode for a first run or after a long gap: paces requests, backs off after 5 consecutive non-200 responses, and stops cleanly after 20 (likely rate-limit/shadowban) |
 | `-v`, `--verbose` | Verbose step-level logging to stderr |
+
+> **First run, or first in a while?** SHiFT readily rate-limits a large redemption
+> (it answers with 302s once it's throttling you). Run with `--rampup` the first time,
+> or after months away, to pace requests and stop cleanly instead of getting
+> shadowbanned. bl3auto reminds you when it looks like a first or long-overdue run.
+
+#### Platforms
+
+bl3auto redeems each code on **every platform linked to your SHiFT account** — the
+site returns one redemption form per linked service, so a "universal" code is redeemed
+once per linked platform (e.g. Steam *and* Epic). To cover more platforms (PSN, Xbox,
+Nintendo, Stadia), link them once at
+[shift.gearboxsoftware.com](https://shift.gearboxsoftware.com) and bl3auto will pick
+them up automatically. Use `--platform` to narrow redemption to a subset of services.
 
 #### Code sources
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run it with `--help` to view command line args that are supported.
 | `--config <path>` | Use a local `config.json` instead of the published remote config |
 | `--dryrun` | Discover and match codes but do not redeem (no side effects) |
 | `--rampup` | Cautious mode for a first run or after a long gap: paces requests, backs off after 5 consecutive non-200 responses, and stops cleanly after 20 (likely rate-limit/shadowban) |
+| `--migrate` | Upgrade the redeemed-codes cache file in place to the current version and exit (no login; `-e` selects the per-account cache) |
 | `-v`, `--verbose` | Verbose step-level logging to stderr |
 
 > **First run, or first in a while?** SHiFT readily rate-limits a large redemption

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Run it with `--help` to view command line args that are supported.
 | `--dryrun` | Discover and match codes but do not redeem (no side effects) |
 | `--rampup` | Cautious mode for a first run or after a long gap: paces requests, backs off after 5 consecutive non-200 responses, and stops cleanly after 20 (likely rate-limit/shadowban) |
 | `--count <n>` | Stop and save after `n` successful redemptions (`0` = no limit) |
+| `--refresh` | Re-query codes already redeemed on every linked platform (run after linking a new platform on your SHiFT account) |
 | `--migrate` | Upgrade the redeemed-codes cache file in place to the current version and exit (no login; `-e` selects the per-account cache) |
 | `-v`, `--verbose` | Verbose step-level logging to stderr |
 
@@ -71,7 +72,10 @@ Use `--v1` or `--v2` to force a single source.
 #### Redeemed-codes cache
 
 bl3auto remembers what it has already redeemed (and which codes are expired) in a
-per-account JSON file so it doesn't reattempt them. If a `codes/` directory exists in
+per-account JSON file so it doesn't reattempt them. Codes redeemed on every linked
+platform — and expired codes — are skipped without even a query on later runs to cut
+request volume; if you link a new platform on your SHiFT account, run with `--refresh`
+once so those codes are re-checked. If a `codes/` directory exists in
 the working directory, that file is stored there — the same path the Docker image
 mounts its volume onto — so a native run from the project directory shares the cache
 with Docker. Otherwise it falls back to the per-user OS config directory

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Run it with `--help` to view command line args that are supported.
 > or after months away, to pace requests and stop cleanly instead of getting
 > shadowbanned. bl3auto reminds you when it looks like a first or long-overdue run.
 
+On bulk runs the request pacing is **adaptive**: it automatically slows down when SHiFT
+starts throttling (302s) and speeds back up after a clean streak, so it settles on the
+fastest rate SHiFT tolerates without you having to tune anything. `-v` shows the interval
+adjusting in real time.
+
 #### Platforms
 
 bl3auto redeems each code on **every platform linked to your SHiFT account** — the

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jauderho/bl3auto/badge)](https://securityscorecards.dev/viewer/?uri=github.com/jauderho/bl3auto)
 
 Cross platform Go app for automatically redeeming SHiFT codes
-for all Borderlands and Wonderlands games.
+for all Borderlands and Wonderlands games, including **Borderlands 4**.
 
 This was forked from matt1484's [repo](https://github.com/matt1484/bl3_auto_vip) as it appears to be no longer maintained. Since VIP is discontinued, all VIP code has been removed. This will only redeem SHiFT codes going forward.
+
+Authentication uses the Gearbox SHiFT website (`shift.gearboxsoftware.com`) directly,
+following the login + redemption flow (the old `api.2k.com` Borderlands API is gone).
 
 
 ## Getting Started
@@ -22,6 +25,31 @@ This was forked from matt1484's [repo](https://github.com/matt1484/bl3_auto_vip)
 
 
 Run it with `--help` to view command line args that are supported.
+
+### Command line flags
+
+| Flag | Description |
+|---|---|
+| `-e`, `--email` | SHiFT account email (prompted if omitted) |
+| `-p`, `--password` | SHiFT account password (prompted if omitted) |
+| `--shift-code <code>` | Redeem a single SHiFT code instead of the full list |
+| `--allow-inactive` | Attempt to redeem inactive SHiFT codes too |
+| `--v1` | Force the original orcicorn code source |
+| `--v2` | Force the newer ugoogalizer/mentalmars code source |
+| `--platform <list>` | Comma-separated services to redeem on (`steam,epic,psn,xboxlive,nintendo,stadia`); default: all offered |
+| `--config <path>` | Use a local `config.json` instead of the published remote config |
+| `--dryrun` | Discover and match codes but do not redeem (no side effects) |
+| `-v`, `--verbose` | Verbose step-level logging to stderr |
+
+#### Code sources
+
+bl3auto reads SHiFT codes from two sources and, by default, uses the newer (v2)
+source and falls back to the original (v1) source only if v2 is unavailable:
+
+- **v2** (default) — [ugoogalizer/autoshift-codes](https://github.com/ugoogalizer/autoshift-codes) (`shiftcodes.json`, includes Borderlands 4)
+- **v1** — [jauderho/shift-codes](https://github.com/jauderho/shift-codes) (orcicorn `index.json`)
+
+Use `--v1` or `--v2` to force a single source.
 
 ### Installing
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Use `--v1` or `--v2` to force a single source.
 #### Redeemed-codes cache
 
 bl3auto remembers what it has already redeemed (and which codes are expired) in a
-per-account JSON file so it doesn't reattempt them. Codes redeemed on every linked
+per-account JSON file so it doesn't reattempt them. Progress is crash-safe: pressing
+Ctrl-C stops the run cleanly with what's been redeemed saved, and the cache is also
+checkpointed periodically during a run, so an interruption never forces you to re-query
+everything (which would only trip SHiFT's rate limit faster). Codes redeemed on every linked
 platform — and expired codes — are skipped without even a query on later runs to cut
 request volume; if you link a new platform on your SHiFT account, run with `--refresh`
 once so those codes are re-checked. If a `codes/` directory exists in

--- a/client.go
+++ b/client.go
@@ -208,7 +208,7 @@ func NewBl3Client(configPath string) (*Bl3Client, error) {
 
 func (client *Bl3Client) logf(format string, args ...any) {
 	if client.Verbose {
-		fmt.Fprintf(os.Stderr, "[verbose] "+format+"\n", args...)
+		_, _ = fmt.Fprintf(os.Stderr, "[verbose] "+format+"\n", args...)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -49,9 +49,12 @@ type HttpClient struct {
 	headers http.Header
 
 	// Request pacing (see SetThrottle). Zero minInterval disables pacing.
-	minInterval time.Duration
-	jitter      time.Duration
-	lastRequest time.Time
+	// minInterval adapts at runtime (see Slowdown/Speedup); minIntervalFloor is
+	// the configured base it never drops below.
+	minInterval      time.Duration
+	minIntervalFloor time.Duration
+	jitter           time.Duration
+	lastRequest      time.Time
 }
 
 type HttpResponse struct {
@@ -130,9 +133,43 @@ func (client *HttpClient) SetDefaultHeader(k, v string) {
 // SetThrottle paces outgoing requests so consecutive calls are spaced at least
 // minInterval apart, plus a random amount up to jitter. This keeps bulk
 // redemption under SHiFT's rate limits and makes traffic look less bot-like.
+// minInterval also becomes the floor that adaptive speed-ups never drop below.
 func (client *HttpClient) SetThrottle(minInterval, jitter time.Duration) {
 	client.minInterval = minInterval
+	client.minIntervalFloor = minInterval
 	client.jitter = jitter
+}
+
+// CurrentInterval reports the current minimum request spacing, which adapts at
+// runtime via Slowdown/Speedup.
+func (client *HttpClient) CurrentInterval() time.Duration {
+	return client.minInterval
+}
+
+// Slowdown widens the request spacing multiplicatively (on a rate-limit signal),
+// capped at ceil. The jitter is unchanged. A no-op when pacing is disabled.
+func (client *HttpClient) Slowdown(factor float64, ceil time.Duration) {
+	if client.minInterval <= 0 || factor <= 1 {
+		return
+	}
+	next := time.Duration(float64(client.minInterval) * factor)
+	if next > ceil {
+		next = ceil
+	}
+	client.minInterval = next
+}
+
+// Speedup narrows the request spacing additively (after a clean streak), never
+// below the floor set by SetThrottle. A no-op when pacing is disabled.
+func (client *HttpClient) Speedup(step time.Duration) {
+	if client.minInterval <= 0 || step <= 0 {
+		return
+	}
+	if next := client.minInterval - step; next > client.minIntervalFloor {
+		client.minInterval = next
+	} else {
+		client.minInterval = client.minIntervalFloor
+	}
 }
 
 // pace sleeps as needed to honour the configured request spacing.

--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/thedevsaddam/gojsonq/v2"
 )
 
 // ErrRateLimited is returned when SHiFT responds with 429 (Too Many Requests)
@@ -143,17 +142,6 @@ func (response *HttpResponse) BodyAsHtmlDoc() (*goquery.Document, error) {
 	return doc, nil
 }
 
-func (response *HttpResponse) BodyAsJson() (*gojsonq.JSONQ, error) {
-	defer func() { _ = response.Body.Close() }()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, errors.New("invalid response json")
-	}
-
-	return JsonFromBytes(bodyBytes), nil
-}
-
 func getResponse(res *http.Response, err error) (*HttpResponse, error) {
 	if err != nil {
 		return nil, err
@@ -253,14 +241,6 @@ func (client *HttpClient) GetWithHeaders(rawurl string, headers map[string]strin
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
-	}
-	return client.Do(req)
-}
-
-func (client *HttpClient) Head(rawurl string) (*HttpResponse, error) {
-	req, err := http.NewRequest("HEAD", rawurl, nil)
-	if err != nil {
-		return nil, err
 	}
 	return client.Do(req)
 }

--- a/client.go
+++ b/client.go
@@ -165,8 +165,9 @@ func fetchBytes(rawurl string) ([]byte, error) {
 
 type Bl3Client struct {
 	HttpClient
-	Config  Bl3Config
-	Verbose bool
+	Config    Bl3Config
+	Verbose   bool
+	csrfToken string // cached session CSRF token for redemption requests
 }
 
 // NewBl3Client builds a client from config. When configPath is non-empty the
@@ -231,6 +232,23 @@ func (client *Bl3Client) getCsrfToken(pageUrl string) (string, error) {
 		return token, nil
 	}
 	return "", errors.New("csrf token not found")
+}
+
+// redemptionToken returns a session CSRF token for redemption requests, fetching
+// it once from the redemption page and caching it. The token is sent only as the
+// X-CSRF-Token header on GET requests (which Rails does not CSRF-validate), so a
+// single cached value is reused for the whole run; each redemption POST uses the
+// per-form authenticity_token instead.
+func (client *Bl3Client) redemptionToken() (string, error) {
+	if client.csrfToken != "" {
+		return client.csrfToken, nil
+	}
+	token, err := client.getCsrfToken(client.Config.BaseUrl + "/code_redemptions/new")
+	if err != nil {
+		return "", err
+	}
+	client.csrfToken = token
+	return token, nil
 }
 
 // Login authenticates against the GearBox SHiFT website: fetch the login page

--- a/client.go
+++ b/client.go
@@ -23,6 +23,15 @@ import (
 // or 503 (Service Unavailable). Callers should back off rather than retry hard.
 var ErrRateLimited = errors.New("rate limited by SHiFT")
 
+// CodeQueryStatusError is returned by GetCodeRedemptionForms when the code-query GET
+// answers with a non-200, non-rate-limit status (commonly a 302 redirect — SHiFT's
+// soft rate-limit / shadowban signal). Callers count these to back off and stop.
+type CodeQueryStatusError struct{ Status int }
+
+func (e *CodeQueryStatusError) Error() string {
+	return fmt.Sprintf("code query returned status %d", e.Status)
+}
+
 // remoteConfigUrl is the location of the published runtime config. It is fetched
 // at startup so the GearBox endpoints can be hot-fixed without a release. It is a
 // var so tests can point it elsewhere.

--- a/client.go
+++ b/client.go
@@ -23,13 +23,53 @@ import (
 // or 503 (Service Unavailable). Callers should back off rather than retry hard.
 var ErrRateLimited = errors.New("rate limited by SHiFT")
 
+// RateLimitError carries a 429/503 rate-limit response, including any Retry-After
+// the server specified so callers can honour it instead of guessing a backoff. It
+// satisfies errors.Is(err, ErrRateLimited), so existing sentinel checks keep working.
+type RateLimitError struct {
+	Status     int
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("rate limited by SHiFT (status %d)", e.Status)
+}
+
+func (e *RateLimitError) Is(target error) bool { return target == ErrRateLimited }
+
 // CodeQueryStatusError is returned by GetCodeRedemptionForms when the code-query GET
 // answers with a non-200, non-rate-limit status (commonly a 302 redirect — SHiFT's
-// soft rate-limit / shadowban signal). Callers count these to back off and stop.
-type CodeQueryStatusError struct{ Status int }
+// soft rate-limit / shadowban signal). Location is the redirect target (used to tell
+// a lost session apart from a throttle) and RetryAfter any server-specified wait.
+type CodeQueryStatusError struct {
+	Status     int
+	Location   string
+	RetryAfter time.Duration
+}
 
 func (e *CodeQueryStatusError) Error() string {
 	return fmt.Sprintf("code query returned status %d", e.Status)
+}
+
+// parseRetryAfter reads a Retry-After header (delta-seconds or HTTP-date) into a
+// duration. It returns 0 when the header is absent, malformed, or already in the past.
+func parseRetryAfter(h http.Header) time.Duration {
+	v := strings.TrimSpace(h.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 // remoteConfigUrl is the location of the published runtime config. It is fetched

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package bl3auto
 
 import (
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,9 +23,17 @@ import (
 // or 503 (Service Unavailable). Callers should back off rather than retry hard.
 var ErrRateLimited = errors.New("rate limited by SHiFT")
 
-// remoteConfigUrl is the default location of the published runtime config. It is
-// fetched at startup so the GearBox endpoints can be hot-fixed without a release.
-const remoteConfigUrl = "https://raw.githubusercontent.com/jauderho/bl3auto/main/config.json"
+// remoteConfigUrl is the location of the published runtime config. It is fetched
+// at startup so the GearBox endpoints can be hot-fixed without a release. It is a
+// var so tests can point it elsewhere.
+var remoteConfigUrl = "https://raw.githubusercontent.com/jauderho/bl3auto/main/config.json"
+
+// embeddedConfig is the config.json compiled into the binary. It is the fallback
+// used when the remote config is unreachable or incompatible with this build, so
+// a freshly compiled binary always works without --config or network access.
+//
+//go:embed config.json
+var embeddedConfig []byte
 
 type HttpClient struct {
 	http.Client
@@ -219,22 +228,9 @@ func NewBl3Client(configPath string) (*Bl3Client, error) {
 		return nil, errors.New("failed to start client")
 	}
 
-	var configBytes []byte
-	if configPath != "" {
-		configBytes, err = os.ReadFile(configPath)
-		if err != nil {
-			return nil, errors.New("failed to read config '" + configPath + "': " + err.Error())
-		}
-	} else {
-		configBytes, err = fetchBytes(remoteConfigUrl)
-		if err != nil {
-			return nil, errors.New("failed to get config: " + err.Error())
-		}
-	}
-
-	config := Bl3Config{}
-	if err := json.Unmarshal(configBytes, &config); err != nil {
-		return nil, errors.New("failed to parse config: " + err.Error())
+	config, err := loadConfig(configPath)
+	if err != nil {
+		return nil, err
 	}
 
 	for header, value := range config.RequestHeaders {
@@ -245,6 +241,47 @@ func NewBl3Client(configPath string) (*Bl3Client, error) {
 		HttpClient: *client,
 		Config:     config,
 	}, nil
+}
+
+// configComplete reports whether a parsed config carries the endpoints the SHiFT
+// login/redemption flow needs. Used to reject a stale or incompatible remote
+// config (e.g. the pre-2.3.0 schema, which lacks these fields).
+func configComplete(c Bl3Config) bool {
+	return c.BaseUrl != "" && c.HomeUrl != "" && c.LoginUrl != "" &&
+		c.Shift.RedemptionInfoUrl != "" && c.Shift.RedemptionUrl != "" &&
+		c.Shift.CodeListUrlV2 != ""
+}
+
+// loadConfig resolves the runtime config. An explicit --config path is used
+// as-is. Otherwise the published remote config is tried first (so endpoints can
+// be hot-fixed without a release); if it is unreachable, unparseable, or
+// incompatible with this binary, the embedded config.json is used instead.
+func loadConfig(configPath string) (Bl3Config, error) {
+	if configPath != "" {
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			return Bl3Config{}, errors.New("failed to read config '" + configPath + "': " + err.Error())
+		}
+		config := Bl3Config{}
+		if err := json.Unmarshal(data, &config); err != nil {
+			return Bl3Config{}, errors.New("failed to parse config '" + configPath + "': " + err.Error())
+		}
+		return config, nil
+	}
+
+	if data, err := fetchBytes(remoteConfigUrl); err == nil {
+		remote := Bl3Config{}
+		if json.Unmarshal(data, &remote) == nil && configComplete(remote) {
+			return remote, nil
+		}
+	}
+
+	// Remote was missing or incompatible; use the config baked into the binary.
+	config := Bl3Config{}
+	if err := json.Unmarshal(embeddedConfig, &config); err != nil {
+		return Bl3Config{}, errors.New("failed to parse embedded config: " + err.Error())
+	}
+	return config, nil
 }
 
 func (client *Bl3Client) logf(format string, args ...any) {

--- a/client.go
+++ b/client.go
@@ -186,6 +186,11 @@ func (client *HttpClient) PostForm(rawurl string, data url.Values, headers map[s
 // fetchBytes retrieves a public URL using the default (redirect-following) HTTP
 // client. Used for the remote config and SHiFT code lists hosted on GitHub raw,
 // which may 302 to a CDN and so cannot use the no-redirect SHiFT client.
+//
+// Accept-Encoding is deliberately left unset: Go's transport then adds
+// "Accept-Encoding: gzip" automatically and transparently decompresses the
+// response, so the ~234 KB code list is fetched gzip-compressed for free.
+// Setting the header manually would disable that automatic decompression.
 func fetchBytes(rawurl string) ([]byte, error) {
 	resp, err := http.Get(rawurl) //nolint:gosec // URLs come from trusted config
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -1,16 +1,24 @@
 package bl3auto
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/thedevsaddam/gojsonq/v2"
 )
+
+// remoteConfigUrl is the default location of the published runtime config. It is
+// fetched at startup so the GearBox endpoints can be hot-fixed without a release.
+const remoteConfigUrl = "https://raw.githubusercontent.com/jauderho/bl3auto/main/config.json"
 
 type HttpClient struct {
 	http.Client
@@ -30,9 +38,20 @@ func NewHttpClient() (*HttpClient, error) {
 	return &HttpClient{
 		http.Client{
 			Jar: jar,
+			// Don't auto-follow redirects: the SHiFT login (302) and code
+			// redemption (302) flows need to inspect the Location header and
+			// drive the redirect chain manually, mirroring autoshift.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 		http.Header{
-			"User-Agent": []string{"BL3 Auto SHiFT"},
+			// Browser-like headers; the SHiFT site rejects the old "BL3 Auto SHiFT"
+			// User-Agent. Accept-Encoding is intentionally left unset so Go's
+			// transport negotiates and transparently decompresses gzip.
+			"User-Agent":      []string{"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0"},
+			"Accept":          []string{"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+			"Accept-Language": []string{"en-US,en;q=0.5"},
 		},
 	}, nil
 }
@@ -64,9 +83,15 @@ func (response *HttpResponse) BodyAsJson() (*gojsonq.JSONQ, error) {
 }
 
 func getResponse(res *http.Response, err error) (*HttpResponse, error) {
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errors.New("received nil response")
+	}
 	return &HttpResponse{
 		*res,
-	}, err
+	}, nil
 }
 
 func (client *HttpClient) SetDefaultHeader(k, v string) {
@@ -74,7 +99,12 @@ func (client *HttpClient) SetDefaultHeader(k, v string) {
 }
 
 func (client *HttpClient) Do(req *http.Request) (*HttpResponse, error) {
+	// Default headers only fill in what the caller hasn't set, so per-request
+	// headers (Referer, X-CSRF-Token, X-Requested-With, ...) are preserved.
 	for k, v := range client.headers {
+		if req.Header.Get(k) != "" {
+			continue
+		}
 		for _, x := range v {
 			req.Header.Set(k, x)
 		}
@@ -82,61 +112,89 @@ func (client *HttpClient) Do(req *http.Request) (*HttpResponse, error) {
 	return getResponse(client.Client.Do(req))
 }
 
-func (client *HttpClient) Get(url string) (*HttpResponse, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func (client *HttpClient) Get(rawurl string) (*HttpResponse, error) {
+	return client.GetWithHeaders(rawurl, nil)
+}
+
+func (client *HttpClient) GetWithHeaders(rawurl string, headers map[string]string) (*HttpResponse, error) {
+	req, err := http.NewRequest("GET", rawurl, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return client.Do(req)
+}
+
+func (client *HttpClient) Head(rawurl string) (*HttpResponse, error) {
+	req, err := http.NewRequest("HEAD", rawurl, nil)
 	if err != nil {
 		return nil, err
 	}
 	return client.Do(req)
 }
 
-func (client *HttpClient) Head(url string) (*HttpResponse, error) {
-	req, err := http.NewRequest("HEAD", url, nil)
+// PostForm submits url-encoded form data with optional per-request headers.
+func (client *HttpClient) PostForm(rawurl string, data url.Values, headers map[string]string) (*HttpResponse, error) {
+	req, err := http.NewRequest("POST", rawurl, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 	return client.Do(req)
 }
 
-func (client *HttpClient) Post(url, contentType string, body io.Reader) (*HttpResponse, error) {
-	req, err := http.NewRequest("POST", url, body)
+// fetchBytes retrieves a public URL using the default (redirect-following) HTTP
+// client. Used for the remote config and SHiFT code lists hosted on GitHub raw,
+// which may 302 to a CDN and so cannot use the no-redirect SHiFT client.
+func fetchBytes(rawurl string) ([]byte, error) {
+	resp, err := http.Get(rawurl) //nolint:gosec // URLs come from trusted config
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", contentType)
-	return client.Do(req)
-}
-
-func (client *HttpClient) PostJson(url string, data any) (*HttpResponse, error) {
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s returned status %d", rawurl, resp.StatusCode)
 	}
-	return client.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	return io.ReadAll(resp.Body)
 }
 
 type Bl3Client struct {
 	HttpClient
-	Config Bl3Config
+	Config  Bl3Config
+	Verbose bool
 }
 
-func NewBl3Client() (*Bl3Client, error) {
+// NewBl3Client builds a client from config. When configPath is non-empty the
+// config is read from that local file (useful for testing new URLs before they
+// are merged); otherwise it is fetched from the published remote config.
+func NewBl3Client(configPath string) (*Bl3Client, error) {
 	client, err := NewHttpClient()
 	if err != nil {
 		return nil, errors.New("failed to start client")
 	}
 
-	res, err := client.Get("https://raw.githubusercontent.com/jauderho/bl3auto/main/config.json")
-	if err != nil {
-		return nil, errors.New("failed to get config")
+	var configBytes []byte
+	if configPath != "" {
+		configBytes, err = os.ReadFile(configPath)
+		if err != nil {
+			return nil, errors.New("failed to read config '" + configPath + "': " + err.Error())
+		}
+	} else {
+		configBytes, err = fetchBytes(remoteConfigUrl)
+		if err != nil {
+			return nil, errors.New("failed to get config: " + err.Error())
+		}
 	}
 
-	configJson, err := res.BodyAsJson()
-	if err != nil {
-		return nil, errors.New("failed to get config")
-	}
 	config := Bl3Config{}
-	configJson.Out(&config)
+	if err := json.Unmarshal(configBytes, &config); err != nil {
+		return nil, errors.New("failed to parse config: " + err.Error())
+	}
 
 	for header, value := range config.RequestHeaders {
 		client.SetDefaultHeader(header, value)
@@ -148,32 +206,74 @@ func NewBl3Client() (*Bl3Client, error) {
 	}, nil
 }
 
+func (client *Bl3Client) logf(format string, args ...any) {
+	if client.Verbose {
+		fmt.Fprintf(os.Stderr, "[verbose] "+format+"\n", args...)
+	}
+}
+
+// getCsrfToken fetches a SHiFT page and extracts its CSRF token. SHiFT exposes
+// the token in a <meta name="csrf-token"> tag on rendered pages and in the
+// login form's hidden authenticity_token input; we try both.
+func (client *Bl3Client) getCsrfToken(pageUrl string) (string, error) {
+	res, err := client.Get(pageUrl)
+	if err != nil {
+		return "", err
+	}
+	doc, err := res.BodyAsHtmlDoc()
+	if err != nil {
+		return "", err
+	}
+	if token, ok := doc.Find(`meta[name="csrf-token"]`).Attr("content"); ok && token != "" {
+		return token, nil
+	}
+	if token, ok := doc.Find(`input[name="authenticity_token"]`).Attr("value"); ok && token != "" {
+		return token, nil
+	}
+	return "", errors.New("csrf token not found")
+}
+
+// Login authenticates against the GearBox SHiFT website: fetch the login page
+// for a CSRF token, then POST the credentials. On success the session cookie is
+// stored in the client's cookie jar and used for subsequent requests.
 func (client *Bl3Client) Login(username string, password string) error {
-	data := map[string]string{
-		"username": username,
-		"password": password,
-	}
-
-	loginRes, err := client.PostJson(client.Config.LoginUrl, data)
+	token, err := client.getCsrfToken(client.Config.HomeUrl)
 	if err != nil {
-		return errors.New("failed to submit login credentials")
+		return errors.New("failed to load login page: " + err.Error())
 	}
-	defer func() { _ = loginRes.Body.Close() }()
+	client.logf("got login csrf token (%d chars)", len(token))
 
-	if loginRes.StatusCode != 200 {
-		return errors.New("failed to login")
-	}
+	form := url.Values{}
+	form.Set("utf8", "✓")
+	form.Set("authenticity_token", token)
+	form.Set("user[email]", username)
+	form.Set("user[password]", password)
+	form.Set("commit", "SIGN IN")
 
-	/* if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
-		return errors.New("Failed to start session")
-	}
-
-	sessionRes, err := client.Get(loginRes.Header.Get(client.Config.LoginRedirectHeader))
+	res, err := client.PostForm(client.Config.LoginUrl, form, map[string]string{
+		"Referer": client.Config.HomeUrl,
+	})
 	if err != nil {
-		return errors.New("Failed to get session")
+		return errors.New("failed to submit login credentials: " + err.Error())
 	}
-	defer sessionRes.Body.Close()*/
+	defer func() { _ = res.Body.Close() }()
+	client.logf("POST %s -> %d", client.Config.LoginUrl, res.StatusCode)
 
-	client.SetDefaultHeader(client.Config.SessionHeader, loginRes.Header.Get(client.Config.SessionIdHeader))
-	return nil
+	switch res.StatusCode {
+	case http.StatusFound, http.StatusSeeOther, http.StatusMovedPermanently:
+		location := res.Header.Get("Location")
+		// A failed login bounces back to the home page with redirect_to=false.
+		if strings.Contains(location, "redirect_to=false") {
+			return errors.New("login failed - invalid email or password")
+		}
+		// Success: the cookie jar already captured the new _session_id.
+		return nil
+	case http.StatusServiceUnavailable:
+		return errors.New("SHiFT login service is temporarily unavailable (503); please try again later")
+	case http.StatusOK:
+		// SHiFT re-renders the login form (200) instead of redirecting on failure.
+		return errors.New("login failed - invalid email or password")
+	default:
+		return errors.New("unexpected login response status: " + strconv.Itoa(res.StatusCode))
+	}
 }

--- a/client.go
+++ b/client.go
@@ -5,16 +5,22 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/thedevsaddam/gojsonq/v2"
 )
+
+// ErrRateLimited is returned when SHiFT responds with 429 (Too Many Requests)
+// or 503 (Service Unavailable). Callers should back off rather than retry hard.
+var ErrRateLimited = errors.New("rate limited by SHiFT")
 
 // remoteConfigUrl is the default location of the published runtime config. It is
 // fetched at startup so the GearBox endpoints can be hot-fixed without a release.
@@ -23,6 +29,11 @@ const remoteConfigUrl = "https://raw.githubusercontent.com/jauderho/bl3auto/main
 type HttpClient struct {
 	http.Client
 	headers http.Header
+
+	// Request pacing (see SetThrottle). Zero minInterval disables pacing.
+	minInterval time.Duration
+	jitter      time.Duration
+	lastRequest time.Time
 }
 
 type HttpResponse struct {
@@ -36,7 +47,7 @@ func NewHttpClient() (*HttpClient, error) {
 	}
 
 	return &HttpClient{
-		http.Client{
+		Client: http.Client{
 			Jar: jar,
 			// Don't auto-follow redirects: the SHiFT login (302) and code
 			// redemption (302) flows need to inspect the Location header and
@@ -45,7 +56,7 @@ func NewHttpClient() (*HttpClient, error) {
 				return http.ErrUseLastResponse
 			},
 		},
-		http.Header{
+		headers: http.Header{
 			// Browser-like headers; the SHiFT site rejects the old "BL3 Auto SHiFT"
 			// User-Agent. Accept-Encoding is intentionally left unset so Go's
 			// transport negotiates and transparently decompresses gzip.
@@ -98,7 +109,31 @@ func (client *HttpClient) SetDefaultHeader(k, v string) {
 	client.headers.Set(k, v)
 }
 
+// SetThrottle paces outgoing requests so consecutive calls are spaced at least
+// minInterval apart, plus a random amount up to jitter. This keeps bulk
+// redemption under SHiFT's rate limits and makes traffic look less bot-like.
+func (client *HttpClient) SetThrottle(minInterval, jitter time.Duration) {
+	client.minInterval = minInterval
+	client.jitter = jitter
+}
+
+// pace sleeps as needed to honour the configured request spacing.
+func (client *HttpClient) pace() {
+	if client.minInterval <= 0 {
+		return
+	}
+	target := client.minInterval
+	if client.jitter > 0 {
+		target += time.Duration(rand.Int64N(int64(client.jitter) + 1))
+	}
+	if d := time.Until(client.lastRequest.Add(target)); d > 0 {
+		time.Sleep(d)
+	}
+	client.lastRequest = time.Now()
+}
+
 func (client *HttpClient) Do(req *http.Request) (*HttpResponse, error) {
+	client.pace()
 	// Default headers only fill in what the caller hasn't set, so per-request
 	// headers (Referer, X-CSRF-Token, X-Requested-With, ...) are preserved.
 	for k, v := range client.headers {
@@ -286,6 +321,8 @@ func (client *Bl3Client) Login(username string, password string) error {
 		}
 		// Success: the cookie jar already captured the new _session_id.
 		return nil
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("%w during login (status 429); please try again later", ErrRateLimited)
 	case http.StatusServiceUnavailable:
 		return errors.New("SHiFT login service is temporarily unavailable (503); please try again later")
 	case http.StatusOK:

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package bl3auto
 
 import (
+	"compress/gzip"
 	"errors"
 	"io"
 	"net/http"
@@ -136,6 +137,33 @@ func TestFetchBytes(t *testing.T) {
 	}
 	if _, err := fetchBytes("http://127.0.0.1:0/nope"); err == nil {
 		t.Error("fetchBytes should error on bad host")
+	}
+}
+
+// TestFetchBytesGzip proves the code-list download is gzip-efficient: Go's
+// transport requests gzip automatically (since we don't set Accept-Encoding)
+// and transparently decompresses the response.
+func TestFetchBytesGzip(t *testing.T) {
+	var sawAcceptEncoding string
+	const payload = "the shift code list, hypothetically large and compressible"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAcceptEncoding = r.Header.Get("Accept-Encoding")
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		_, _ = gz.Write([]byte(payload))
+		_ = gz.Close()
+	}))
+	defer srv.Close()
+
+	b, err := fetchBytes(srv.URL)
+	if err != nil {
+		t.Fatalf("fetchBytes: %v", err)
+	}
+	if !strings.Contains(sawAcceptEncoding, "gzip") {
+		t.Errorf("client should request gzip, got Accept-Encoding=%q", sawAcceptEncoding)
+	}
+	if string(b) != payload {
+		t.Errorf("body should be transparently decompressed, got %q", string(b))
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package bl3auto
 
 import (
 	"compress/gzip"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -243,6 +244,84 @@ func TestNewBl3ClientErrors(t *testing.T) {
 	_ = os.WriteFile(bad, []byte("not json"), 0o600)
 	if _, err := NewBl3Client(bad); err == nil {
 		t.Error("expected error for invalid json")
+	}
+}
+
+func TestConfigComplete(t *testing.T) {
+	full := Bl3Config{BaseUrl: "b", HomeUrl: "h", LoginUrl: "l"}
+	full.Shift.RedemptionInfoUrl = "r"
+	full.Shift.RedemptionUrl = "rr"
+	full.Shift.CodeListUrlV2 = "v2"
+	if !configComplete(full) {
+		t.Error("a fully populated config should be complete")
+	}
+	// The pre-2.3.0 schema lacks HomeUrl (and the others) -> incomplete.
+	noHome := full
+	noHome.HomeUrl = ""
+	if configComplete(noHome) {
+		t.Error("config without HomeUrl should be incomplete")
+	}
+
+	// The embedded config must itself be complete, or fallback is useless.
+	embedded := Bl3Config{}
+	if err := json.Unmarshal(embeddedConfig, &embedded); err != nil {
+		t.Fatalf("embedded config does not parse: %v", err)
+	}
+	if !configComplete(embedded) {
+		t.Errorf("embedded config.json is incomplete: %+v", embedded)
+	}
+}
+
+func TestNewBl3ClientFallsBackToEmbedded(t *testing.T) {
+	// Remote returns the old, incompatible schema (as main does pre-merge).
+	oldSchema := `{"version":"2.2.28","loginUrl":"https://api.2k.com/borderlands/users/authenticate","shiftConfig":{"codeListUrl":"x"}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, oldSchema)
+	}))
+	defer srv.Close()
+	orig := remoteConfigUrl
+	remoteConfigUrl = srv.URL
+	defer func() { remoteConfigUrl = orig }()
+
+	c, err := NewBl3Client("")
+	if err != nil {
+		t.Fatalf("NewBl3Client: %v", err)
+	}
+	if !configComplete(c.Config) || c.Config.HomeUrl == "" {
+		t.Errorf("expected embedded (complete) config, got %+v", c.Config)
+	}
+	if strings.Contains(c.Config.LoginUrl, "api.2k.com") {
+		t.Error("should not have used the stale remote login URL")
+	}
+}
+
+func TestNewBl3ClientFallbackWhenRemoteUnreachable(t *testing.T) {
+	orig := remoteConfigUrl
+	remoteConfigUrl = "http://127.0.0.1:0/nope"
+	defer func() { remoteConfigUrl = orig }()
+
+	c, err := NewBl3Client("")
+	if err != nil || !configComplete(c.Config) {
+		t.Errorf("unreachable remote should fall back to embedded: err=%v cfg=%+v", err, c.Config)
+	}
+}
+
+func TestNewBl3ClientUsesValidRemote(t *testing.T) {
+	remote := `{"version":"9.9.9","baseUrl":"https://x","homeUrl":"https://x/home","loginUrl":"https://x/sessions","shiftConfig":{"codeListUrlV2":"https://x/v2","redemptionInfoUrl":"https://x/e","redemptionUrl":"https://x/c"}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, remote)
+	}))
+	defer srv.Close()
+	orig := remoteConfigUrl
+	remoteConfigUrl = srv.URL
+	defer func() { remoteConfigUrl = orig }()
+
+	c, err := NewBl3Client("")
+	if err != nil {
+		t.Fatalf("NewBl3Client: %v", err)
+	}
+	if c.Config.Version != "9.9.9" || c.Config.HomeUrl != "https://x/home" {
+		t.Errorf("expected the valid remote config to be used, got %+v", c.Config)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -54,12 +54,11 @@ func redemptionFormHTML(code string, services ...string) string {
 
 // --- HTTP plumbing -------------------------------------------------------
 
-func TestHttpClientGetHeadAndDefaults(t *testing.T) {
-	var gotUA, gotReferer, gotMethod string
+func TestHttpClientGetAndDefaults(t *testing.T) {
+	var gotUA, gotReferer string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotUA = r.Header.Get("User-Agent")
 		gotReferer = r.Header.Get("Referer")
-		gotMethod = r.Method
 		_, _ = io.WriteString(w, "hello")
 	}))
 	defer srv.Close()
@@ -87,13 +86,6 @@ func TestHttpClientGetHeadAndDefaults(t *testing.T) {
 	}
 	if gotReferer != "https://override.example/" {
 		t.Errorf("per-request Referer should win, got %q", gotReferer)
-	}
-
-	if _, err := c.Head(srv.URL); err != nil {
-		t.Fatalf("Head: %v", err)
-	}
-	if gotMethod != "HEAD" {
-		t.Errorf("expected HEAD, got %q", gotMethod)
 	}
 }
 
@@ -168,11 +160,9 @@ func TestFetchBytesGzip(t *testing.T) {
 	}
 }
 
-func TestBodyAsJsonAndHtmlDoc(t *testing.T) {
+func TestBodyAsHtmlDoc(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/json":
-			_, _ = io.WriteString(w, `{"a":1}`)
 		case "/html":
 			_, _ = io.WriteString(w, metaTokenPage)
 		default:
@@ -182,19 +172,8 @@ func TestBodyAsJsonAndHtmlDoc(t *testing.T) {
 	defer srv.Close()
 	c, _ := NewHttpClient()
 
-	res, _ := c.Get(srv.URL + "/json")
-	jq, err := res.BodyAsJson()
-	if err != nil {
-		t.Fatalf("BodyAsJson: %v", err)
-	}
-	var v float64
-	jq.From("a").Out(&v)
-	if v != 1 {
-		t.Errorf("expected a=1, got %v", v)
-	}
-
-	res2, _ := c.Get(srv.URL + "/html")
-	doc, err := res2.BodyAsHtmlDoc()
+	res, _ := c.Get(srv.URL + "/html")
+	doc, err := res.BodyAsHtmlDoc()
 	if err != nil {
 		t.Fatalf("BodyAsHtmlDoc: %v", err)
 	}
@@ -202,8 +181,8 @@ func TestBodyAsJsonAndHtmlDoc(t *testing.T) {
 		t.Errorf("meta token = %q", tok)
 	}
 
-	res3, _ := c.Get(srv.URL + "/missing")
-	if _, err := res3.BodyAsHtmlDoc(); err == nil {
+	res2, _ := c.Get(srv.URL + "/missing")
+	if _, err := res2.BodyAsHtmlDoc(); err == nil {
 		t.Error("BodyAsHtmlDoc should error on non-200")
 	}
 }
@@ -684,13 +663,7 @@ func TestStatusFromTextAllBranches(t *testing.T) {
 	}
 }
 
-func TestStringSetAndContains(t *testing.T) {
-	s := StringSet{}
-	s.Add("steam")
-	if _, ok := s["steam"]; !ok {
-		t.Error("StringSet.Add failed")
-	}
-
+func TestShiftCodeMapContains(t *testing.T) {
 	m := ShiftCodeMap{"CODE": {"steam", "epic"}}
 	if !m.Contains("CODE", "steam") {
 		t.Error("Contains should be true for steam")

--- a/client_test.go
+++ b/client_test.go
@@ -427,6 +427,9 @@ func TestGetCodeRedemptionForms(t *testing.T) {
 			_, _ = io.WriteString(w, redemptionFormHTML("GOODCODE", "steam", "epic"))
 		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "USEDCODE":
 			_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has already been redeemed</div>`)
+		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "RL302":
+			w.Header().Set("Location", "/home")
+			w.WriteHeader(http.StatusFound) // soft rate-limit / shadowban
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -450,8 +453,18 @@ func TestGetCodeRedemptionForms(t *testing.T) {
 		t.Fatalf("used code: forms=%d reason=%q err=%v", len(forms), reason, err)
 	}
 
-	if _, _, err := c.GetCodeRedemptionForms("INVALID"); err == nil {
-		t.Error("expected error for 500 response")
+	// A non-200, non-rate-limit status surfaces as a typed CodeQueryStatusError
+	// carrying the status, so the caller can count consecutive failures (--rampup).
+	var statusErr *CodeQueryStatusError
+	if _, _, err := c.GetCodeRedemptionForms("INVALID"); !errors.As(err, &statusErr) || statusErr.Status != 500 {
+		t.Errorf("expected CodeQueryStatusError{500}, got %v", err)
+	}
+	statusErr = nil
+	if _, _, err := c.GetCodeRedemptionForms("RL302"); !errors.As(err, &statusErr) || statusErr.Status != http.StatusFound {
+		t.Errorf("expected CodeQueryStatusError{302} on redirect, got %v", err)
+	}
+	if statusErr != nil && statusErr.Error() != "code query returned status 302" {
+		t.Errorf("unexpected error message: %q", statusErr.Error())
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package bl3auto
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestClient builds a Bl3Client whose endpoints all point at the given test
@@ -534,6 +536,47 @@ func TestStringSetAndContains(t *testing.T) {
 	}
 	if m.Contains("MISSING", "steam") {
 		t.Error("Contains should be false for missing code")
+	}
+}
+
+func TestThrottlePacing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	c, _ := NewHttpClient()
+	c.SetThrottle(30*time.Millisecond, 0)
+
+	start := time.Now()
+	for range 3 {
+		if _, err := c.Get(srv.URL); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// First request isn't delayed; the next two are spaced ~30ms each.
+	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
+		t.Errorf("expected pacing to add ~60ms across 3 requests, got %v", elapsed)
+	}
+}
+
+func TestRateLimitedDetection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, metaTokenPage)
+		case "/entitlement_offer_codes":
+			w.WriteHeader(http.StatusTooManyRequests)
+		case "/code_redemptions":
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	if _, _, err := c.GetCodeRedemptionForms("X"); !errors.Is(err, ErrRateLimited) {
+		t.Errorf("entitlement 429 should report ErrRateLimited, got %v", err)
+	}
+	if err := c.RedeemForm(RedemptionForm{Service: "steam", Fields: map[string]string{"a": "b"}}); !errors.Is(err, ErrRateLimited) {
+		t.Errorf("redemption 503 should report ErrRateLimited, got %v", err)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -678,6 +678,42 @@ func TestThrottlePacing(t *testing.T) {
 	}
 }
 
+func TestThrottleSlowdownSpeedup(t *testing.T) {
+	c, _ := NewHttpClient()
+	c.SetThrottle(100*time.Millisecond, 0)
+	if c.CurrentInterval() != 100*time.Millisecond {
+		t.Fatalf("SetThrottle should set the interval (and floor), got %s", c.CurrentInterval())
+	}
+
+	// Slowdown multiplies the interval, capped at ceil.
+	c.Slowdown(2.0, time.Second)
+	if c.CurrentInterval() != 200*time.Millisecond {
+		t.Errorf("expected 200ms after 2x slowdown, got %s", c.CurrentInterval())
+	}
+	c.Slowdown(10, 500*time.Millisecond) // 200ms*10 = 2s, capped at 500ms
+	if c.CurrentInterval() != 500*time.Millisecond {
+		t.Errorf("expected slowdown capped at 500ms, got %s", c.CurrentInterval())
+	}
+
+	// Speedup subtracts, floored at the configured base (100ms).
+	c.Speedup(150 * time.Millisecond) // 500 - 150 = 350
+	if c.CurrentInterval() != 350*time.Millisecond {
+		t.Errorf("expected 350ms after speedup, got %s", c.CurrentInterval())
+	}
+	c.Speedup(time.Second) // would drop below the floor; clamp to 100ms
+	if c.CurrentInterval() != 100*time.Millisecond {
+		t.Errorf("expected clamp to floor 100ms, got %s", c.CurrentInterval())
+	}
+
+	// When pacing is disabled, both adjustments are no-ops.
+	c.SetThrottle(0, 0)
+	c.Slowdown(2, time.Second)
+	c.Speedup(time.Millisecond)
+	if c.CurrentInterval() != 0 {
+		t.Errorf("disabled pacing should stay 0, got %s", c.CurrentInterval())
+	}
+}
+
 func TestRateLimitedDetection(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/client_test.go
+++ b/client_test.go
@@ -429,6 +429,7 @@ func TestGetCodeRedemptionForms(t *testing.T) {
 			_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has already been redeemed</div>`)
 		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "RL302":
 			w.Header().Set("Location", "/home")
+			w.Header().Set("Retry-After", "2")
 			w.WriteHeader(http.StatusFound) // soft rate-limit / shadowban
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
@@ -463,8 +464,51 @@ func TestGetCodeRedemptionForms(t *testing.T) {
 	if _, _, err := c.GetCodeRedemptionForms("RL302"); !errors.As(err, &statusErr) || statusErr.Status != http.StatusFound {
 		t.Errorf("expected CodeQueryStatusError{302} on redirect, got %v", err)
 	}
-	if statusErr != nil && statusErr.Error() != "code query returned status 302" {
-		t.Errorf("unexpected error message: %q", statusErr.Error())
+	if statusErr != nil {
+		if statusErr.Error() != "code query returned status 302" {
+			t.Errorf("unexpected error message: %q", statusErr.Error())
+		}
+		// The redirect target and Retry-After are surfaced so the caller can tell a
+		// lost session from a throttle and honour the server's backoff.
+		if statusErr.Location != "/home" {
+			t.Errorf("expected Location /home, got %q", statusErr.Location)
+		}
+		if statusErr.RetryAfter != 2*time.Second {
+			t.Errorf("expected RetryAfter 2s, got %s", statusErr.RetryAfter)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	mk := func(v string) http.Header {
+		h := http.Header{}
+		if v != "" {
+			h.Set("Retry-After", v)
+		}
+		return h
+	}
+	if d := parseRetryAfter(mk("")); d != 0 {
+		t.Errorf("absent header should be 0, got %s", d)
+	}
+	if d := parseRetryAfter(mk("5")); d != 5*time.Second {
+		t.Errorf("expected 5s, got %s", d)
+	}
+	if d := parseRetryAfter(mk("0")); d != 0 {
+		t.Errorf("zero seconds should be 0, got %s", d)
+	}
+	if d := parseRetryAfter(mk("-3")); d != 0 {
+		t.Errorf("negative should be 0, got %s", d)
+	}
+	if d := parseRetryAfter(mk("garbage")); d != 0 {
+		t.Errorf("garbage should be 0, got %s", d)
+	}
+	future := time.Now().Add(time.Hour).UTC().Format(http.TimeFormat)
+	if d := parseRetryAfter(mk(future)); d <= 0 || d > time.Hour+time.Minute {
+		t.Errorf("future HTTP-date should be ~1h, got %s", d)
+	}
+	past := time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)
+	if d := parseRetryAfter(mk(past)); d != 0 {
+		t.Errorf("past HTTP-date should be 0, got %s", d)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -428,6 +428,55 @@ func TestGetShiftCodesAndFailover(t *testing.T) {
 	}
 }
 
+func TestGetShiftCodesV2AllowInactive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, v2Fixture) // 3 entries, 1 flagged expired
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+	c.Config.Shift.CodeListUrlV2 = srv.URL + "/v2.json"
+
+	// Default: expired codes are dropped.
+	if codes, err := c.GetShiftCodesV2(); err != nil || len(codes) != 2 {
+		t.Errorf("default: expected 2 non-expired codes, got %d (err=%v)", len(codes), err)
+	}
+
+	// AllowInactive: expired codes are included.
+	c.Config.Shift.AllowInactive = true
+	if codes, err := c.GetShiftCodesV2(); err != nil || len(codes) != 3 {
+		t.Errorf("allow-inactive: expected 3 codes incl. expired, got %d (err=%v)", len(codes), err)
+	}
+}
+
+func TestRedemptionTokenCaching(t *testing.T) {
+	var tokenHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/code_redemptions/new":
+			tokenHits++
+			_, _ = io.WriteString(w, metaTokenPage)
+		case "/entitlement_offer_codes":
+			_, _ = io.WriteString(w, redemptionFormHTML(r.URL.Query().Get("code"), "steam"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	for _, code := range []string{"CODE1", "CODE2", "CODE3"} {
+		if _, _, err := c.GetCodeRedemptionForms(code); err != nil {
+			t.Fatalf("GetCodeRedemptionForms(%s): %v", code, err)
+		}
+	}
+	if tokenHits != 1 {
+		t.Errorf("expected the CSRF token endpoint to be fetched once, got %d hits", tokenHits)
+	}
+	if c.csrfToken != "test-token-12345" {
+		t.Errorf("token not cached on client, got %q", c.csrfToken)
+	}
+}
+
 // --- small helpers -------------------------------------------------------
 
 func TestAbsoluteUrl(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,498 @@
+package bl3auto
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestClient builds a Bl3Client whose endpoints all point at the given test
+// server base URL.
+func newTestClient(t *testing.T, baseURL string) *Bl3Client {
+	t.Helper()
+	hc, err := NewHttpClient()
+	if err != nil {
+		t.Fatalf("NewHttpClient: %v", err)
+	}
+	c := &Bl3Client{HttpClient: *hc}
+	c.Config.BaseUrl = baseURL
+	c.Config.HomeUrl = baseURL + "/home"
+	c.Config.LoginUrl = baseURL + "/sessions"
+	c.Config.Shift.RedemptionInfoUrl = baseURL + "/entitlement_offer_codes"
+	c.Config.Shift.RedemptionUrl = baseURL + "/code_redemptions"
+	c.Config.Shift.CodeListUrlV1 = baseURL + "/v1.json"
+	c.Config.Shift.CodeListUrlV2 = baseURL + "/v2.json"
+	return c
+}
+
+const metaTokenPage = `<html><head><meta name="csrf-token" content="test-token-12345"></head><body>ok</body></html>`
+
+// redemptionFormHTML returns the entitlement_offer_codes partial for a code,
+// offering the given services.
+func redemptionFormHTML(code string, services ...string) string {
+	var b strings.Builder
+	b.WriteString(`<h2>Borderlands 4</h2>`)
+	for _, svc := range services {
+		b.WriteString(`<form class="new_archway_code_redemption" id="new_archway_code_redemption">`)
+		b.WriteString(`<input type="hidden" name="authenticity_token" value="form-tok">`)
+		b.WriteString(`<input type="hidden" name="archway_code_redemption[code]" value="` + code + `">`)
+		b.WriteString(`<input type="hidden" name="archway_code_redemption[check]" value="chk">`)
+		b.WriteString(`<input id="archway_code_redemption_service" name="archway_code_redemption[service]" value="` + svc + `">`)
+		b.WriteString(`</form>`)
+	}
+	return b.String()
+}
+
+// --- HTTP plumbing -------------------------------------------------------
+
+func TestHttpClientGetHeadAndDefaults(t *testing.T) {
+	var gotUA, gotReferer, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		gotReferer = r.Header.Get("Referer")
+		gotMethod = r.Method
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer srv.Close()
+
+	c, err := NewHttpClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.SetDefaultHeader("Referer", "https://default.example/")
+
+	// Plain Get: default headers applied.
+	if _, err := c.Get(srv.URL); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !strings.Contains(gotUA, "Mozilla/5.0") {
+		t.Errorf("default User-Agent not applied, got %q", gotUA)
+	}
+	if gotReferer != "https://default.example/" {
+		t.Errorf("default Referer not applied, got %q", gotReferer)
+	}
+
+	// Per-request header must win over the default.
+	if _, err := c.GetWithHeaders(srv.URL, map[string]string{"Referer": "https://override.example/"}); err != nil {
+		t.Fatalf("GetWithHeaders: %v", err)
+	}
+	if gotReferer != "https://override.example/" {
+		t.Errorf("per-request Referer should win, got %q", gotReferer)
+	}
+
+	if _, err := c.Head(srv.URL); err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if gotMethod != "HEAD" {
+		t.Errorf("expected HEAD, got %q", gotMethod)
+	}
+}
+
+func TestPostForm(t *testing.T) {
+	var gotBody, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotCT = r.Header.Get("Content-Type")
+	}))
+	defer srv.Close()
+
+	c, _ := NewHttpClient()
+	form := map[string][]string{"user[email]": {"a@b.com"}, "x": {"y"}}
+	if _, err := c.PostForm(srv.URL, form, map[string]string{"Referer": "r"}); err != nil {
+		t.Fatalf("PostForm: %v", err)
+	}
+	if gotCT != "application/x-www-form-urlencoded" {
+		t.Errorf("content-type = %q", gotCT)
+	}
+	if !strings.Contains(gotBody, "user%5Bemail%5D=a%40b.com") || !strings.Contains(gotBody, "x=y") {
+		t.Errorf("unexpected encoded body: %q", gotBody)
+	}
+}
+
+func TestFetchBytes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/bad" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = io.WriteString(w, "payload")
+	}))
+	defer srv.Close()
+
+	b, err := fetchBytes(srv.URL + "/good")
+	if err != nil || string(b) != "payload" {
+		t.Fatalf("fetchBytes good: %q, %v", b, err)
+	}
+	if _, err := fetchBytes(srv.URL + "/bad"); err == nil {
+		t.Error("fetchBytes should error on non-200")
+	}
+	if _, err := fetchBytes("http://127.0.0.1:0/nope"); err == nil {
+		t.Error("fetchBytes should error on bad host")
+	}
+}
+
+func TestBodyAsJsonAndHtmlDoc(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/json":
+			_, _ = io.WriteString(w, `{"a":1}`)
+		case "/html":
+			_, _ = io.WriteString(w, metaTokenPage)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c, _ := NewHttpClient()
+
+	res, _ := c.Get(srv.URL + "/json")
+	jq, err := res.BodyAsJson()
+	if err != nil {
+		t.Fatalf("BodyAsJson: %v", err)
+	}
+	var v float64
+	jq.From("a").Out(&v)
+	if v != 1 {
+		t.Errorf("expected a=1, got %v", v)
+	}
+
+	res2, _ := c.Get(srv.URL + "/html")
+	doc, err := res2.BodyAsHtmlDoc()
+	if err != nil {
+		t.Fatalf("BodyAsHtmlDoc: %v", err)
+	}
+	if tok, _ := doc.Find(`meta[name="csrf-token"]`).Attr("content"); tok != "test-token-12345" {
+		t.Errorf("meta token = %q", tok)
+	}
+
+	res3, _ := c.Get(srv.URL + "/missing")
+	if _, err := res3.BodyAsHtmlDoc(); err == nil {
+		t.Error("BodyAsHtmlDoc should error on non-200")
+	}
+}
+
+// --- config --------------------------------------------------------------
+
+func TestNewBl3ClientLocalConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	cfg := `{
+		"version": "9.9.9",
+		"baseUrl": "https://shift.example",
+		"requestHeaders": {"Origin": "https://o.example"},
+		"shiftConfig": {"codeListUrlV2": "https://v2", "codeListUrlV1": "https://v1"}
+	}`
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := NewBl3Client(path)
+	if err != nil {
+		t.Fatalf("NewBl3Client: %v", err)
+	}
+	if c.Config.Version != "9.9.9" || c.Config.BaseUrl != "https://shift.example" {
+		t.Errorf("config not parsed: %+v", c.Config)
+	}
+	if c.headers.Get("Origin") != "https://o.example" {
+		t.Errorf("request headers not applied, got %q", c.headers.Get("Origin"))
+	}
+}
+
+func TestNewBl3ClientErrors(t *testing.T) {
+	if _, err := NewBl3Client(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Error("expected error for missing config file")
+	}
+
+	bad := filepath.Join(t.TempDir(), "bad.json")
+	_ = os.WriteFile(bad, []byte("not json"), 0o600)
+	if _, err := NewBl3Client(bad); err == nil {
+		t.Error("expected error for invalid json")
+	}
+}
+
+// --- auth ----------------------------------------------------------------
+
+func TestGetCsrfToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/meta":
+			_, _ = io.WriteString(w, metaTokenPage)
+		case "/input":
+			_, _ = io.WriteString(w, `<form><input name="authenticity_token" value="input-tok"></form>`)
+		case "/none":
+			_, _ = io.WriteString(w, `<html><body>nothing here</body></html>`)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	if tok, err := c.getCsrfToken(srv.URL + "/meta"); err != nil || tok != "test-token-12345" {
+		t.Errorf("meta token: %q, %v", tok, err)
+	}
+	if tok, err := c.getCsrfToken(srv.URL + "/input"); err != nil || tok != "input-tok" {
+		t.Errorf("input token: %q, %v", tok, err)
+	}
+	if _, err := c.getCsrfToken(srv.URL + "/none"); err == nil {
+		t.Error("expected error when no token present")
+	}
+}
+
+func TestLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/home" {
+			_, _ = io.WriteString(w, metaTokenPage)
+			return
+		}
+		// /sessions
+		_ = r.ParseForm()
+		switch r.Form.Get("user[email]") {
+		case "good@x.com":
+			http.SetCookie(w, &http.Cookie{Name: "_session_id", Value: "sess-abc"})
+			w.Header().Set("Location", "/account")
+			w.WriteHeader(http.StatusFound)
+		case "down@x.com":
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case "ok200@x.com":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.Header().Set("Location", "/home?redirect_to=false")
+			w.WriteHeader(http.StatusFound)
+		}
+	}))
+	defer srv.Close()
+
+	cases := []struct {
+		email   string
+		wantErr bool
+	}{
+		{"good@x.com", false},
+		{"bad@x.com", true},
+		{"down@x.com", true},
+		{"ok200@x.com", true},
+	}
+	for _, tc := range cases {
+		c := newTestClient(t, srv.URL)
+		c.Verbose = true // exercise logf
+		err := c.Login(tc.email, "pw")
+		if (err != nil) != tc.wantErr {
+			t.Errorf("Login(%s): err=%v, wantErr=%v", tc.email, err, tc.wantErr)
+		}
+	}
+
+	// After a successful login the session cookie should be sent on later requests.
+	c := newTestClient(t, srv.URL)
+	if err := c.Login("good@x.com", "pw"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	var sawCookie string
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ck, err := r.Cookie("_session_id"); err == nil {
+			sawCookie = ck.Value
+		}
+	}))
+	defer srv2.Close()
+	// The cookie was set for srv's host; verify the jar stored it.
+	if got := c.Jar.Cookies(mustParseURL(t, srv.URL)); len(got) == 0 || got[0].Value != "sess-abc" {
+		t.Errorf("session cookie not stored in jar: %+v", got)
+	}
+	_ = sawCookie
+}
+
+// --- redemption ----------------------------------------------------------
+
+func TestGetCodeRedemptionForms(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/code_redemptions/new":
+			_, _ = io.WriteString(w, metaTokenPage)
+		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "GOODCODE":
+			if r.Header.Get("X-Requested-With") != "XMLHttpRequest" {
+				t.Error("missing X-Requested-With header")
+			}
+			_, _ = io.WriteString(w, redemptionFormHTML("GOODCODE", "steam", "epic"))
+		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "USEDCODE":
+			_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has already been redeemed</div>`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	forms, reason, err := c.GetCodeRedemptionForms("GOODCODE")
+	if err != nil || reason != "" {
+		t.Fatalf("good code: reason=%q err=%v", reason, err)
+	}
+	if len(forms) != 2 || forms[0].Service != "steam" || forms[1].Service != "epic" {
+		t.Fatalf("unexpected forms: %+v", forms)
+	}
+	if forms[0].Fields["archway_code_redemption[code]"] != "GOODCODE" {
+		t.Errorf("form fields not parsed: %+v", forms[0].Fields)
+	}
+
+	forms, reason, err = c.GetCodeRedemptionForms("USEDCODE")
+	if err != nil || len(forms) != 0 || !strings.Contains(reason, "already been redeemed") {
+		t.Fatalf("used code: forms=%d reason=%q err=%v", len(forms), reason, err)
+	}
+
+	if _, _, err := c.GetCodeRedemptionForms("INVALID"); err == nil {
+		t.Error("expected error for 500 response")
+	}
+}
+
+func TestRedeemFormSuccessViaPoll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, metaTokenPage)
+		case "/code_redemptions":
+			w.Header().Set("Location", "/code_redemptions/77")
+			w.WriteHeader(http.StatusFound)
+		case "/code_redemptions/77":
+			_, _ = io.WriteString(w, `<div id="check_redemption_status" data-url="/code_redemptions/77/status"></div>`)
+		case "/code_redemptions/77/status":
+			_, _ = io.WriteString(w, `{"text":"Your code was successfully redeemed"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	form := RedemptionForm{Service: "steam", Fields: map[string]string{
+		"authenticity_token": "x", "archway_code_redemption[code]": "C",
+	}}
+	if err := c.RedeemForm(form); err != nil {
+		t.Fatalf("RedeemForm should succeed, got %v", err)
+	}
+}
+
+func TestRedeemFormAlreadyRedeemedAlert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/code_redemptions" {
+			_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has already been redeemed</div>`)
+			return
+		}
+		_, _ = io.WriteString(w, metaTokenPage)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	err := c.RedeemForm(RedemptionForm{Service: "steam", Fields: map[string]string{"a": "b"}})
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "already") {
+		t.Fatalf("expected already-redeemed error, got %v", err)
+	}
+}
+
+// --- code lists ----------------------------------------------------------
+
+func TestGetShiftCodesAndFailover(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, v2Fixture)
+		case "/v1.json":
+			_, _ = io.WriteString(w, v1Fixture)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv.URL)
+
+	if v2, err := c.GetShiftCodesV2(); err != nil || len(v2) != 2 {
+		t.Errorf("v2: %d codes, err=%v", len(v2), err)
+	}
+	if v1, err := c.GetShiftCodesV1(); err != nil || len(v1) != 2 {
+		t.Errorf("v1: %d codes, err=%v", len(v1), err)
+	}
+	if def, err := c.GetShiftCodes(""); err != nil || len(def) != 2 {
+		t.Errorf("default: %d codes, err=%v", len(def), err)
+	}
+	if forced, err := c.GetShiftCodes("v1"); err != nil || len(forced) != 2 {
+		t.Errorf("forced v1: %d codes, err=%v", len(forced), err)
+	}
+
+	// Failover: break v2, expect v1 results.
+	c.Config.Shift.CodeListUrlV2 = srv.URL + "/missing.json"
+	c.Verbose = true
+	fb, err := c.GetShiftCodes("")
+	if err != nil || len(fb) != 2 {
+		t.Errorf("failover: %d codes, err=%v", len(fb), err)
+	}
+}
+
+// --- small helpers -------------------------------------------------------
+
+func TestAbsoluteUrl(t *testing.T) {
+	c := &Bl3Client{}
+	c.Config.BaseUrl = "https://shift.example"
+	cases := map[string]string{
+		"/code_redemptions/1":     "https://shift.example/code_redemptions/1",
+		"code_redemptions/1":      "https://shift.example/code_redemptions/1",
+		"https://other.example/x": "https://other.example/x",
+		"http://other.example/y":  "http://other.example/y",
+	}
+	for in, want := range cases {
+		if got := c.absoluteUrl(in); got != want {
+			t.Errorf("absoluteUrl(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStatusFromTextAllBranches(t *testing.T) {
+	cases := []struct {
+		text    string
+		visited bool
+		wantErr bool
+	}{
+		{"", true, false},
+		{"", false, true},
+		{"Success!", false, false},
+		{"already been redeemed", false, true},
+		{"this code has expired", false, true},
+		{"not available", false, true},
+		{"please launch a SHiFT-enabled title", false, true},
+		{"some other message", false, true},
+	}
+	for _, tc := range cases {
+		err := statusFromText(tc.text, tc.visited)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("statusFromText(%q,%v) err=%v wantErr=%v", tc.text, tc.visited, err, tc.wantErr)
+		}
+	}
+}
+
+func TestStringSetAndContains(t *testing.T) {
+	s := StringSet{}
+	s.Add("steam")
+	if _, ok := s["steam"]; !ok {
+		t.Error("StringSet.Add failed")
+	}
+
+	m := ShiftCodeMap{"CODE": {"steam", "epic"}}
+	if !m.Contains("CODE", "steam") {
+		t.Error("Contains should be true for steam")
+	}
+	if m.Contains("CODE", "psn") {
+		t.Error("Contains should be false for psn")
+	}
+	if m.Contains("MISSING", "steam") {
+		t.Error("Contains should be false for missing code")
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -15,6 +15,8 @@
 //	    --v2                Force the newer ugoogalizer/mentalmars code source
 //	    --platform <list>   Comma-separated services to redeem on
 //	                        (steam,epic,psn,xboxlive,nintendo,stadia); default: all offered
+//	    --game <list>       Comma-separated games to redeem (substring match; default: all)
+//	    --skip-game <list>  Comma-separated games to skip (substring match)
 //	    --config <path>     Use a local config.json instead of the published remote config
 //	    --dryrun            Discover and match codes but do not redeem (no side effects)
 //	    --rampup            Cautious mode for a first run / long gap: pace requests,
@@ -40,6 +42,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -59,18 +62,23 @@ var (
 	rateLimitRetries  = 5                      // give up (stop the run) after this many
 )
 
-// --rampup tuning. Rampup is the cautious mode for a first run or after a long gap,
-// where SHiFT readily soft-rate-limits us with 302s on the code-query. It paces
-// requests much more slowly and reacts to *consecutive* non-200 responses: back off
-// after rampupBackoffAfter in a row, and stop the run after rampupStopAfter (a likely
-// shadowban). All are vars so tests can shrink them.
+// Consecutive non-200 (commonly 302) handling for bulk runs. SHiFT soft-rate-limits
+// by redirecting the code-query, so on every bulk run we back off after backoffAfter
+// such responses in a row and stop the run after stopAfter (a likely shadowban),
+// saving progress. --rampup adds slower request pacing on top. All vars so tests can
+// shrink them.
 var (
-	rampupThrottleBase   = 1500 * time.Millisecond // minimum spacing between requests in rampup
-	rampupThrottleJitter = 1500 * time.Millisecond // added random spacing (0..jitter)
-	rampupBackoffBase    = 5 * time.Second         // first backoff after rampupBackoffAfter
-	rampupBackoffMax     = 60 * time.Second        // backoff ceiling
-	rampupBackoffAfter   = 5                       // consecutive non-200 → start backing off
-	rampupStopAfter      = 20                      // consecutive non-200 → stop the run
+	backoffAfter = 5               // consecutive non-200 → start backing off
+	stopAfter    = 20              // consecutive non-200 → stop the run
+	backoffBase  = 5 * time.Second // first backoff after backoffAfter
+	backoffMax   = 60 * time.Second
+)
+
+// --rampup request pacing: much slower spacing than the normal bulk throttle, for a
+// first run or after a long gap when SHiFT throttles aggressively.
+var (
+	rampupThrottleBase   = 1500 * time.Millisecond
+	rampupThrottleJitter = 1500 * time.Millisecond
 )
 
 // bulkThreshold is the candidate-code count at or above which a run is treated
@@ -130,6 +138,8 @@ type shiftOptions struct {
 	source          string // "v1", "v2", or "" for default failover
 	singleShiftCode string
 	platformFilter  []string
+	gameInclude     []string // only redeem these games (substring match; empty = all)
+	gameSkip        []string // skip these games (substring match)
 	dryrun          bool
 	rampup          bool
 	refresh         bool // re-query codes marked complete (pick up newly-linked platforms)
@@ -175,6 +185,59 @@ func allServicesRedeemed(m bl3.ShiftCodeMap, code string, forms []bl3.Redemption
 	return true
 }
 
+// splitCSV splits a comma-separated flag value into trimmed, non-empty tokens.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// matchesGame reports whether a code's game passes the include/skip filters
+// (case-insensitive substring). An empty include list matches every game; a game
+// matching any skip term is excluded (skip wins over include).
+func matchesGame(include, skip []string, game string) bool {
+	g := strings.ToLower(game)
+	for _, s := range skip {
+		if s = strings.ToLower(strings.TrimSpace(s)); s != "" && strings.Contains(g, s) {
+			return false
+		}
+	}
+	if len(include) == 0 {
+		return true
+	}
+	for _, in := range include {
+		if in = strings.ToLower(strings.TrimSpace(in)); in != "" && strings.Contains(g, in) {
+			return true
+		}
+	}
+	return false
+}
+
+// accountPlatforms returns the sorted set of real services (platforms) seen in the
+// cache — i.e. the platforms this account has redeemed on. Sentinel markers are
+// excluded.
+func accountPlatforms(m bl3.ShiftCodeMap) []string {
+	set := map[string]struct{}{}
+	for _, services := range m {
+		for _, s := range services {
+			if s == expiredMarker || s == completeMarker {
+				continue
+			}
+			set[s] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
+}
+
 // redeemedCache is the versioned on-disk format of the redeemed-codes cache. Older
 // files are a bare ShiftCodeMap (no wrapper); readRedeemedCache reads both.
 type redeemedCache struct {
@@ -199,6 +262,10 @@ Flags:
       --v2                Force the newer ugoogalizer/mentalmars code source
       --platform <list>   Comma-separated services to redeem on; default: all offered
                           (valid: steam, epic, psn, xboxlive, nintendo, stadia)
+      --game <list>       Comma-separated games to redeem (substring match; default: all),
+                          e.g. --game "borderlands 3,wonderlands"
+      --skip-game <list>  Comma-separated games to skip (substring match),
+                          e.g. --skip-game "borderlands 4"
       --config <path>     Use a local config.json instead of the published remote config
       --dryrun            Discover and match codes but do not redeem (no side effects)
       --rampup            Cautious mode for a first run or after a long gap: paces
@@ -225,6 +292,9 @@ Examples:
 
   # First run, or first in a long while: redeem cautiously
   bl3auto -e you@example.com -p 'secret' --rampup
+
+  # Skip a game you don't own yet (substring match, case-insensitive)
+  bl3auto -e you@example.com -p 'secret' --skip-game 'borderlands 4'
 
   # Redeem a single code on Steam only
   bl3auto -e you@example.com -p 'secret' --shift-code ABCDE-... --platform steam
@@ -377,6 +447,13 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 			fmt.Println("         with --rampup to pace requests and stop cleanly if throttled.")
 		}
 
+		// Pre-flight: show which platforms this account can redeem on (derived from
+		// the cache) so the user can confirm their account is linked as expected.
+		if plats := accountPlatforms(redeemedCodes); len(plats) > 0 {
+			fmt.Println("Account can redeem on: " + strings.Join(plats, ", ") +
+				" (from cache; link more at shift.gearboxsoftware.com to add platforms)")
+		}
+
 		label := "Getting new SHIFT codes"
 		if opts.source != "" {
 			label += " (" + opts.source + ")"
@@ -387,8 +464,22 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 			printError(err)
 			return
 		}
-		codes = list
 		fmt.Println(SUCCESS)
+
+		// Filter the candidate list by game before querying anything — this is the
+		// one filter that cuts code-query volume (codes for unwanted games are never
+		// queried). --refresh ignores the filters for a full re-scan.
+		if !opts.refresh && (len(opts.gameInclude) > 0 || len(opts.gameSkip) > 0) {
+			kept := make([]bl3.ShiftCode, 0, len(list))
+			for _, sc := range list {
+				if matchesGame(opts.gameInclude, opts.gameSkip, sc.Game) {
+					kept = append(kept, sc)
+				}
+			}
+			fmt.Printf("Game filter: %d of %d codes match.\n", len(kept), len(list))
+			list = kept
+		}
+		codes = list
 	}
 
 	// Pace requests and back off on rate limits for bulk runs; --rampup forces this
@@ -424,6 +515,10 @@ codeLoop:
 			continue
 		}
 
+		if client.Verbose && sc.Game != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "[verbose] %s — game: %s\n", code, sc.Game)
+		}
+
 		var forms []bl3.RedemptionForm
 		var reason string
 		err, stop := withBackoff(bulk, func() error {
@@ -442,12 +537,12 @@ codeLoop:
 		if errors.As(err, &statusErr) {
 			consecutive++
 			fmt.Println("Skipping '" + code + "': " + err.Error())
-			if opts.rampup && consecutive >= rampupStopAfter {
+			if bulk && consecutive >= stopAfter {
 				stoppedShadowban = true
 				break codeLoop
 			}
-			if opts.rampup && consecutive >= rampupBackoffAfter {
-				wait := rampupBackoff(consecutive)
+			if bulk && consecutive >= backoffAfter {
+				wait := consecutiveBackoff(consecutive)
 				fmt.Printf("         %d non-200 responses in a row; backing off %s . . .\n", consecutive, wait)
 				time.Sleep(wait)
 			}
@@ -554,16 +649,16 @@ codeLoop:
 	}
 }
 
-// rampupBackoff returns the escalating sleep for the Nth consecutive non-200 code
-// query in rampup mode, capped at rampupBackoffMax.
-func rampupBackoff(consecutive int) time.Duration {
-	shift := consecutive - rampupBackoffAfter
+// consecutiveBackoff returns the escalating sleep for the Nth consecutive non-200
+// code query on a bulk run, capped at backoffMax.
+func consecutiveBackoff(consecutive int) time.Duration {
+	shift := consecutive - backoffAfter
 	if shift < 0 {
 		shift = 0
 	}
-	wait := rampupBackoffBase << uint(shift)
-	if wait > rampupBackoffMax || wait <= 0 {
-		wait = rampupBackoffMax
+	wait := backoffBase << uint(shift)
+	if wait > backoffMax || wait <= 0 {
+		wait = backoffMax
 	}
 	return wait
 }
@@ -577,6 +672,8 @@ func main() {
 		useV1           bool
 		useV2           bool
 		platform        string
+		game            string
+		skipGame        string
 		configPath      string
 		dryrun          bool
 		verbose         bool
@@ -595,6 +692,8 @@ func main() {
 	flag.BoolVar(&useV1, "v1", false, "Force the original orcicorn code source")
 	flag.BoolVar(&useV2, "v2", false, "Force the newer ugoogalizer/mentalmars code source")
 	flag.StringVar(&platform, "platform", "", "Comma-separated services to redeem on (default: all offered)")
+	flag.StringVar(&game, "game", "", "Comma-separated games to redeem (substring match; default: all)")
+	flag.StringVar(&skipGame, "skip-game", "", "Comma-separated games to skip (substring match)")
 	flag.StringVar(&configPath, "config", "", "Use a local config.json instead of the published remote config")
 	flag.BoolVar(&dryrun, "dryrun", false, "Discover and match codes but do not redeem")
 	flag.BoolVar(&rampup, "rampup", false, "Cautious mode for a first run / long gap: pace requests and stop cleanly if throttled")
@@ -619,12 +718,9 @@ func main() {
 		source = "v2"
 	}
 
-	var platformFilter []string
-	for p := range strings.SplitSeq(platform, ",") {
-		if t := strings.TrimSpace(p); t != "" {
-			platformFilter = append(platformFilter, t)
-		}
-	}
+	platformFilter := splitCSV(platform)
+	gameInclude := splitCSV(game)
+	gameSkip := splitCSV(skipGame)
 
 	if username == "" {
 		reader := bufio.NewReader(os.Stdin)
@@ -676,6 +772,8 @@ func main() {
 		source:          source,
 		singleShiftCode: singleShiftCode,
 		platformFilter:  platformFilter,
+		gameInclude:     gameInclude,
+		gameSkip:        gameSkip,
 		dryrun:          dryrun,
 		rampup:          rampup,
 		refresh:         refresh,

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -57,6 +57,12 @@ var (
 // single --shift-code redemption stays fast and un-throttled.
 const bulkThreshold = 5
 
+// resolveCacheFolder returns the folder that stores the redeemed-codes cache —
+// the directory the Docker `codes/` volume maps onto. Overridable in tests.
+var resolveCacheFolder = func() *configdir.Config {
+	return configdir.New("bl3auto", "bl3auto").QueryFolders(configdir.Global)[0]
+}
+
 // withBackoff runs op. When retry is true and op reports ErrRateLimited, it
 // retries with exponential backoff and returns stop=true if the limit persists
 // past rateLimitRetries (the caller should then halt the run). When retry is
@@ -194,21 +200,21 @@ func writeRedeemedCodes(folder *configdir.Config, configFilename string, redeeme
 	return folder.WriteFile(configFilename, data)
 }
 
-func loadRedeemedCodes(configDirs configdir.ConfigDir, configFilename string) bl3.ShiftCodeMap {
+func loadRedeemedCodes(folder *configdir.Config, configFilename string) bl3.ShiftCodeMap {
 	fmt.Print("Getting previously redeemed SHIFT codes . . . . . ")
-	folder := configDirs.QueryFolderContainsFile(configFilename)
-	if folder == nil {
+	codes := readRedeemedCodes(folder, configFilename)
+	if len(codes) == 0 {
 		fmt.Println(NOTFOUND)
-		return bl3.ShiftCodeMap{}
+	} else {
+		fmt.Println(SUCCESS)
 	}
-	fmt.Println(SUCCESS)
-	return readRedeemedCodes(folder, configFilename)
+	return codes
 }
 
 func doShift(client *bl3.Bl3Client, opts shiftOptions) {
-	configDirs := configdir.New("bl3auto", "bl3auto")
+	cacheFolder := resolveCacheFolder()
 	configFilename := usernameHash + "-shift-codes.json"
-	redeemedCodes := loadRedeemedCodes(configDirs, configFilename)
+	redeemedCodes := loadRedeemedCodes(cacheFolder, configFilename)
 
 	// Gather the candidate codes: a single code, or the full list from the source.
 	var codes []bl3.ShiftCode
@@ -318,8 +324,7 @@ codeLoop:
 	}
 
 	if cacheDirty && !opts.dryrun {
-		folders := configDirs.QueryFolders(configdir.Global)
-		if err := writeRedeemedCodes(folders[0], configFilename, redeemedCodes); err != nil {
+		if err := writeRedeemedCodes(cacheFolder, configFilename, redeemedCodes); err != nil {
 			printError(err)
 		}
 	}

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -17,6 +17,8 @@
 //	                        (steam,epic,psn,xboxlive,nintendo,stadia); default: all offered
 //	    --config <path>     Use a local config.json instead of the published remote config
 //	    --dryrun            Discover and match codes but do not redeem (no side effects)
+//	    --rampup            Cautious mode for a first run / long gap: pace requests,
+//	                        back off after 5 consecutive non-200s, stop after 20
 //	-v, --verbose           Verbose step-level logging to stderr
 //	-h, --help              Show this help
 //
@@ -50,6 +52,20 @@ var (
 	rateLimitBaseWait = 2 * time.Second        // first backoff on a 429/503
 	rateLimitMaxWait  = 30 * time.Second       // backoff ceiling
 	rateLimitRetries  = 5                      // give up (stop the run) after this many
+)
+
+// --rampup tuning. Rampup is the cautious mode for a first run or after a long gap,
+// where SHiFT readily soft-rate-limits us with 302s on the code-query. It paces
+// requests much more slowly and reacts to *consecutive* non-200 responses: back off
+// after rampupBackoffAfter in a row, and stop the run after rampupStopAfter (a likely
+// shadowban). All are vars so tests can shrink them.
+var (
+	rampupThrottleBase   = 1500 * time.Millisecond // minimum spacing between requests in rampup
+	rampupThrottleJitter = 1500 * time.Millisecond // added random spacing (0..jitter)
+	rampupBackoffBase    = 5 * time.Second         // first backoff after rampupBackoffAfter
+	rampupBackoffMax     = 60 * time.Second        // backoff ceiling
+	rampupBackoffAfter   = 5                       // consecutive non-200 → start backing off
+	rampupStopAfter      = 20                      // consecutive non-200 → stop the run
 )
 
 // bulkThreshold is the candidate-code count at or above which a run is treated
@@ -103,6 +119,19 @@ type shiftOptions struct {
 	singleShiftCode string
 	platformFilter  []string
 	dryrun          bool
+	rampup          bool
+}
+
+// cacheVersion is the current on-disk schema version of the redeemed-codes cache.
+// Bump it when the layout changes so future migrations can branch on it.
+const cacheVersion = 2
+
+// redeemedCache is the versioned on-disk format of the redeemed-codes cache. Older
+// files are a bare ShiftCodeMap (no wrapper); readRedeemedCache reads both.
+type redeemedCache struct {
+	Version int              `json:"version"`
+	LastRun time.Time        `json:"lastRun"`
+	Codes   bl3.ShiftCodeMap `json:"codes"`
 }
 
 func usage() {
@@ -123,6 +152,9 @@ Flags:
                           (valid: steam, epic, psn, xboxlive, nintendo, stadia)
       --config <path>     Use a local config.json instead of the published remote config
       --dryrun            Discover and match codes but do not redeem (no side effects)
+      --rampup            Cautious mode for a first run or after a long gap: paces
+                          requests, backs off after 5 consecutive non-200 responses,
+                          and stops cleanly after 20 (likely rate-limit/shadowban)
   -v, --verbose           Verbose step-level logging to stderr
   -h, --help              Show this help
 
@@ -136,6 +168,9 @@ Examples:
 
   # See what would be redeemed without redeeming anything
   bl3auto -e you@example.com -p 'secret' --dryrun -v
+
+  # First run, or first in a long while: redeem cautiously
+  bl3auto -e you@example.com -p 'secret' --rampup
 
   # Redeem a single code on Steam only
   bl3auto -e you@example.com -p 'secret' --shift-code ABCDE-... --platform steam
@@ -173,48 +208,72 @@ func summarize(s string) string {
 	return joined
 }
 
-// readRedeemedCodes parses the previously-redeemed-codes cache from a config
-// folder — the directory the Docker `codes/` volume maps onto. A nil folder
-// (no cache dir yet) or an unreadable/empty file yields an empty map.
-func readRedeemedCodes(folder *configdir.Config, configFilename string) bl3.ShiftCodeMap {
-	redeemedCodes := bl3.ShiftCodeMap{}
+// readRedeemedCache parses the previously-redeemed-codes cache from a config folder
+// — the directory the Docker `codes/` volume maps onto. It reads both the current
+// versioned format ({version, lastRun, codes}) and the older bare-map format,
+// returning the codes, the last-run time (zero if unknown), and whether a cache file
+// existed at all. A nil folder or unreadable/empty file yields (empty, zero, false).
+func readRedeemedCache(folder *configdir.Config, configFilename string) (bl3.ShiftCodeMap, time.Time, bool) {
 	if folder == nil {
-		return redeemedCodes
+		return bl3.ShiftCodeMap{}, time.Time{}, false
 	}
 	data, err := folder.ReadFile(configFilename)
 	if err != nil {
-		return redeemedCodes
+		return bl3.ShiftCodeMap{}, time.Time{}, false
 	}
-	if j := bl3.JsonFromBytes(data); j != nil {
-		j.Out(&redeemedCodes)
+
+	// Current format: a wrapper with a "codes" key. The old bare map has no such
+	// key (SHiFT codes never look like "codes"), so Codes stays nil and we fall
+	// through to the back-compat path.
+	var cache redeemedCache
+	if json.Unmarshal(data, &cache) == nil && cache.Codes != nil {
+		return cache.Codes, cache.LastRun, true
 	}
-	return redeemedCodes
+
+	// Back-compat: an old bare ShiftCodeMap. Recency is unknown (zero time).
+	bare := bl3.ShiftCodeMap{}
+	_ = json.Unmarshal(data, &bare)
+	return bare, time.Time{}, true
 }
 
-// writeRedeemedCodes persists the redeemed-codes cache to a config folder.
-func writeRedeemedCodes(folder *configdir.Config, configFilename string, redeemedCodes bl3.ShiftCodeMap) error {
-	data, err := json.MarshalIndent(&redeemedCodes, "", "  ")
+// writeRedeemedCache persists the redeemed-codes cache in the current versioned
+// format, stamping it with the given last-run time.
+func writeRedeemedCache(folder *configdir.Config, configFilename string, codes bl3.ShiftCodeMap, lastRun time.Time) error {
+	if folder == nil {
+		return nil
+	}
+	cache := redeemedCache{Version: cacheVersion, LastRun: lastRun, Codes: codes}
+	data, err := json.MarshalIndent(&cache, "", "  ")
 	if err != nil {
 		return err
 	}
 	return folder.WriteFile(configFilename, data)
 }
 
-func loadRedeemedCodes(folder *configdir.Config, configFilename string) bl3.ShiftCodeMap {
+func loadRedeemedCodes(folder *configdir.Config, configFilename string) (bl3.ShiftCodeMap, time.Time, bool) {
 	fmt.Print("Getting previously redeemed SHIFT codes . . . . . ")
-	codes := readRedeemedCodes(folder, configFilename)
+	codes, lastRun, existed := readRedeemedCache(folder, configFilename)
 	if len(codes) == 0 {
 		fmt.Println(NOTFOUND)
 	} else {
 		fmt.Println(SUCCESS)
 	}
-	return codes
+	return codes, lastRun, existed
+}
+
+// rampupAdvised nudges toward --rampup: a likely first run (no cache), an old-format
+// cache with unknown recency, or a last run more than ~6 months ago.
+func rampupAdvised(existed bool, lastRun, now time.Time) bool {
+	if !existed || lastRun.IsZero() {
+		return true
+	}
+	return lastRun.Before(now.AddDate(0, -6, 0))
 }
 
 func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 	cacheFolder := resolveCacheFolder()
 	configFilename := usernameHash + "-shift-codes.json"
-	redeemedCodes := loadRedeemedCodes(cacheFolder, configFilename)
+	redeemedCodes, lastRun, existed := loadRedeemedCodes(cacheFolder, configFilename)
 
 	// Gather the candidate codes: a single code, or the full list from the source.
 	var codes []bl3.ShiftCode
@@ -223,6 +282,14 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 		codes = []bl3.ShiftCode{{Code: code}}
 		fmt.Println("Checking single SHIFT code '" + code + "'")
 	} else {
+		// Nudge first-time / long-absent users toward --rampup before a bulk run,
+		// where SHiFT is quick to soft-rate-limit us with 302s.
+		if !opts.rampup && rampupAdvised(existed, lastRun, time.Now()) {
+			fmt.Println("WARNING: this looks like a first run or your first in a while.")
+			fmt.Println("         SHiFT may rate-limit a large redemption. Consider re-running")
+			fmt.Println("         with --rampup to pace requests and stop cleanly if throttled.")
+		}
+
 		label := "Getting new SHIFT codes"
 		if opts.source != "" {
 			label += " (" + opts.source + ")"
@@ -237,16 +304,21 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 		fmt.Println(SUCCESS)
 	}
 
-	// Only pace requests and back off on rate limits for bulk runs; a single
-	// (or handful of) code(s) stays fast and un-throttled.
-	bulk := len(codes) >= bulkThreshold
-	if bulk {
+	// Pace requests and back off on rate limits for bulk runs; --rampup forces this
+	// on (with much more conservative spacing) regardless of how many codes there
+	// are. A single (or handful of) code(s) otherwise stays fast and un-throttled.
+	bulk := opts.rampup || len(codes) >= bulkThreshold
+	switch {
+	case opts.rampup:
+		client.SetThrottle(rampupThrottleBase, rampupThrottleJitter)
+	case bulk:
 		client.SetThrottle(throttleBase, throttleJitter)
 	}
 
 	redeemedAny := false
-	cacheDirty := false
 	rateLimited := false
+	stoppedShadowban := false
+	consecutive := 0 // consecutive non-200 code-query responses (see --rampup)
 
 codeLoop:
 	for _, sc := range codes {
@@ -263,15 +335,37 @@ codeLoop:
 			rateLimited = true
 			break codeLoop
 		}
+		// A non-200 code-query (commonly a 302) is SHiFT throttling us. In rampup we
+		// count these: back off after a few in a row, and stop cleanly once it's
+		// clearly a shadowban. A clean (200) response resets the counter.
+		var statusErr *bl3.CodeQueryStatusError
+		if errors.As(err, &statusErr) {
+			consecutive++
+			fmt.Println("Skipping '" + code + "': " + err.Error())
+			if opts.rampup && consecutive >= rampupStopAfter {
+				stoppedShadowban = true
+				break codeLoop
+			}
+			if opts.rampup && consecutive >= rampupBackoffAfter {
+				wait := rampupBackoff(consecutive)
+				fmt.Printf("         %d non-200 responses in a row; backing off %s . . .\n", consecutive, wait)
+				time.Sleep(wait)
+			}
+			continue
+		}
 		if err != nil {
 			fmt.Println("Skipping '" + code + "': " + err.Error())
 			continue
 		}
+		consecutive = 0
 		if len(forms) == 0 {
 			fmt.Println("'" + code + "': " + summarize(reason))
 			continue
 		}
 
+		// One redemption per form: the SHiFT site returns a form for each platform
+		// linked to the account, so a code is redeemed once per linked platform
+		// (--platform narrows this set).
 		for _, form := range forms {
 			if !bl3.ServiceMatches(opts.platformFilter, form.Service) {
 				continue
@@ -302,32 +396,51 @@ codeLoop:
 				low := strings.ToLower(rerr.Error())
 				if strings.Contains(low, "already") || strings.Contains(low, "expired") {
 					redeemedCodes[code] = append(redeemedCodes[code], form.Service)
-					cacheDirty = true
 				}
 			} else {
 				redeemedCodes[code] = append(redeemedCodes[code], form.Service)
-				cacheDirty = true
 				fmt.Println(SUCCESS)
 			}
 		}
 	}
 
-	if rateLimited {
+	switch {
+	case stoppedShadowban:
+		fmt.Printf("Stopped after %d consecutive non-200 responses (likely rate-limited/shadowbanned by SHiFT).\n", consecutive)
+		fmt.Println("Progress saved; wait a while and re-run with --rampup to continue.")
+	case rateLimited:
 		fmt.Println("Stopped early due to repeated SHiFT rate limiting. Progress saved; re-run later to continue.")
-	} else if !redeemedAny {
+	case !redeemedAny:
 		if opts.singleShiftCode != "" {
 			fmt.Println("The single SHIFT code could not be redeemed at this time. Try again later.")
 		} else {
 			fmt.Println("No new SHIFT codes at this time. Try again later.")
 		}
-		return
+		// Still bump lastRun below so the stale-run warning tracks this attempt.
 	}
 
-	if cacheDirty && !opts.dryrun {
-		if err := writeRedeemedCodes(cacheFolder, configFilename, redeemedCodes); err != nil {
+	// On any non-dryrun run, rewrite the cache: this persists newly-redeemed codes,
+	// bumps lastRun (powering the stale-run warning), and upgrades an old bare-map
+	// file to the current versioned format.
+	if !opts.dryrun {
+		if err := writeRedeemedCache(cacheFolder, configFilename, redeemedCodes, time.Now()); err != nil {
 			printError(err)
 		}
 	}
+}
+
+// rampupBackoff returns the escalating sleep for the Nth consecutive non-200 code
+// query in rampup mode, capped at rampupBackoffMax.
+func rampupBackoff(consecutive int) time.Duration {
+	shift := consecutive - rampupBackoffAfter
+	if shift < 0 {
+		shift = 0
+	}
+	wait := rampupBackoffBase << uint(shift)
+	if wait > rampupBackoffMax || wait <= 0 {
+		wait = rampupBackoffMax
+	}
+	return wait
 }
 
 func main() {
@@ -342,6 +455,7 @@ func main() {
 		configPath      string
 		dryrun          bool
 		verbose         bool
+		rampup          bool
 	)
 
 	flag.StringVar(&username, "e", "", "SHiFT account email")
@@ -355,6 +469,7 @@ func main() {
 	flag.StringVar(&platform, "platform", "", "Comma-separated services to redeem on (default: all offered)")
 	flag.StringVar(&configPath, "config", "", "Use a local config.json instead of the published remote config")
 	flag.BoolVar(&dryrun, "dryrun", false, "Discover and match codes but do not redeem")
+	flag.BoolVar(&rampup, "rampup", false, "Cautious mode for a first run / long gap: pace requests and stop cleanly if throttled")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose step-level logging to stderr")
 	flag.BoolVar(&verbose, "v", false, "Verbose step-level logging to stderr")
 	flag.Usage = usage
@@ -424,6 +539,7 @@ func main() {
 		singleShiftCode: singleShiftCode,
 		platformFilter:  platformFilter,
 		dryrun:          dryrun,
+		rampup:          rampup,
 	})
 
 	exit()

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -153,8 +153,17 @@ func withBackoff(retry bool, op func() error) (err error, stop bool) {
 		if attempt > rateLimitRetries {
 			return err, true
 		}
-		fmt.Printf("Rate limited by SHiFT; backing off %s (retry %d/%d) . . .\n", wait, attempt, rateLimitRetries)
-		time.Sleep(wait)
+		// Honour a server-specified Retry-After when present, capped at the ceiling;
+		// otherwise use the exponential backoff.
+		sleep := wait
+		var rle *bl3.RateLimitError
+		if errors.As(err, &rle) && rle.RetryAfter > 0 {
+			if sleep = rle.RetryAfter; sleep > rateLimitMaxWait {
+				sleep = rateLimitMaxWait
+			}
+		}
+		fmt.Printf("Rate limited by SHiFT; backing off %s (retry %d/%d) . . .\n", sleep, attempt, rateLimitRetries)
+		time.Sleep(sleep)
 		if wait *= 2; wait > rateLimitMaxWait {
 			wait = rateLimitMaxWait
 		}
@@ -252,6 +261,19 @@ func matchesGame(include, skip []string, game string) bool {
 		}
 	}
 	return false
+}
+
+// isAuthRedirect reports whether a redirect Location means our SHiFT session is
+// gone (bounced to sign in) rather than a throttle. SHiFT's throttle 302 points at
+// /home, so /home is deliberately excluded — only unambiguous sign-in markers count.
+func isAuthRedirect(loc string) bool {
+	if loc == "" {
+		return false
+	}
+	l := strings.ToLower(loc)
+	return strings.Contains(l, "/login") ||
+		strings.Contains(l, "/sessions") ||
+		strings.Contains(l, "redirect_to=false")
 }
 
 // accountPlatforms returns the sorted set of real services (platforms) seen in the
@@ -533,6 +555,7 @@ func doShift(ctx context.Context, client *bl3.Bl3Client, opts shiftOptions) {
 	redeemedAny := false
 	rateLimited := false
 	stoppedShadowban := false
+	sessionExpired := false
 	reachedCount := false
 	interrupted := false
 	consecutive := 0  // consecutive non-200 code-query responses (see --rampup)
@@ -581,6 +604,12 @@ codeLoop:
 		// clearly a shadowban. A clean (200) response resets the counter.
 		var statusErr *bl3.CodeQueryStatusError
 		if errors.As(err, &statusErr) {
+			// A redirect to sign in means our session is gone, not a throttle:
+			// backing off won't help, so stop and tell the user to re-run.
+			if isAuthRedirect(statusErr.Location) {
+				sessionExpired = true
+				break codeLoop
+			}
 			consecutive++
 			cleanStreak = 0
 			if bulk {
@@ -596,7 +625,11 @@ codeLoop:
 				break codeLoop
 			}
 			if bulk && consecutive >= backoffAfter {
-				wait := consecutiveBackoff(consecutive)
+				// Prefer the server's Retry-After when it sent one.
+				wait := statusErr.RetryAfter
+				if wait <= 0 {
+					wait = consecutiveBackoff(consecutive)
+				}
 				fmt.Printf("         %d non-200 responses in a row; backing off %s . . .\n", consecutive, wait)
 				if !sleepCtx(ctx, wait) {
 					interrupted = true
@@ -702,6 +735,8 @@ codeLoop:
 		fmt.Println("Interrupted. Progress saved; re-run to continue.")
 	case reachedCount:
 		fmt.Printf("Reached the --count limit of %d successful redemption(s). Progress saved; re-run to continue.\n", opts.count)
+	case sessionExpired:
+		fmt.Println("Your SHiFT session expired or you're not signed in. Progress saved; re-run to sign in again.")
 	case stoppedShadowban:
 		fmt.Printf("Stopped after %d consecutive non-200 responses (likely rate-limited/shadowbanned by SHiFT).\n", consecutive)
 		fmt.Println("Progress saved; wait a while and re-run with --rampup to continue.")

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -35,6 +35,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -42,9 +43,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	bl3 "github.com/jauderho/bl3auto"
@@ -85,6 +88,28 @@ var (
 // as "bulk": only then do we pace requests and back off on rate limits. A
 // single --shift-code redemption stays fast and un-throttled.
 const bulkThreshold = 5
+
+// checkpointEvery is how often (in new successful redemptions) the cache is
+// flushed mid-run, bounding progress lost to a hard crash (e.g. kill -9) where
+// the interrupt handler never runs. A var so tests can shrink it.
+var checkpointEvery = 10
+
+// sleepCtx sleeps for d, returning false if the context is cancelled first
+// (e.g. the user pressed Ctrl-C). Used for the long loop-level backoff sleeps so
+// an interrupt aborts promptly instead of waiting out the backoff.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
 
 // resolveCacheFolder returns the folder that stores the redeemed-codes cache.
 // It prefers a local `codes/` directory in the working directory when one exists —
@@ -427,7 +452,7 @@ func runMigrate() {
 	fmt.Printf("Migrated %d codes to cache version %d (in place).\n", len(codes), cacheVersion)
 }
 
-func doShift(client *bl3.Bl3Client, opts shiftOptions) {
+func doShift(ctx context.Context, client *bl3.Bl3Client, opts shiftOptions) {
 	cacheFolder := resolveCacheFolder()
 	configFilename := usernameHash + "-shift-codes.json"
 	redeemedCodes, lastRun, existed := loadRedeemedCodes(cacheFolder, configFilename)
@@ -497,12 +522,20 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 	rateLimited := false
 	stoppedShadowban := false
 	reachedCount := false
+	interrupted := false
 	consecutive := 0  // consecutive non-200 code-query responses (see --rampup)
 	successCount := 0 // new successful redemptions this run (see --count)
 
 codeLoop:
 	for _, sc := range codes {
 		code := sc.Code
+
+		// Bail out cleanly between codes if the user interrupted (Ctrl-C); the
+		// end-of-run cache write below still saves progress.
+		if ctx.Err() != nil {
+			interrupted = true
+			break codeLoop
+		}
 
 		// Skip codes we've already fully resolved, without spending a query:
 		// expired (terminal), or redeemed on every linked platform (complete).
@@ -544,7 +577,10 @@ codeLoop:
 			if bulk && consecutive >= backoffAfter {
 				wait := consecutiveBackoff(consecutive)
 				fmt.Printf("         %d non-200 responses in a row; backing off %s . . .\n", consecutive, wait)
-				time.Sleep(wait)
+				if !sleepCtx(ctx, wait) {
+					interrupted = true
+					break codeLoop
+				}
 			}
 			continue
 		}
@@ -607,6 +643,13 @@ codeLoop:
 				redeemedCodes[code] = append(redeemedCodes[code], form.Service)
 				fmt.Println(SUCCESS)
 				successCount++
+				// Checkpoint periodically so a hard crash (kill -9) loses at most
+				// checkpointEvery redemptions rather than the whole run.
+				if !opts.dryrun && checkpointEvery > 0 && successCount%checkpointEvery == 0 {
+					if err := writeRedeemedCache(cacheFolder, configFilename, redeemedCodes, time.Now()); err != nil {
+						printError(err)
+					}
+				}
 				if opts.count > 0 && successCount >= opts.count {
 					reachedCount = true
 					break codeLoop
@@ -623,6 +666,8 @@ codeLoop:
 	}
 
 	switch {
+	case interrupted:
+		fmt.Println("Interrupted. Progress saved; re-run to continue.")
 	case reachedCount:
 		fmt.Printf("Reached the --count limit of %d successful redemption(s). Progress saved; re-run to continue.\n", opts.count)
 	case stoppedShadowban:
@@ -768,7 +813,12 @@ func main() {
 	}
 	fmt.Println(SUCCESS)
 
-	doShift(client, shiftOptions{
+	// A Ctrl-C (or SIGTERM) during a long, throttled run should stop cleanly and
+	// save progress rather than discard the whole run.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	doShift(ctx, client, shiftOptions{
 		source:          source,
 		singleShiftCode: singleShiftCode,
 		platformFilter:  platformFilter,

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -68,7 +68,7 @@ Flags:
   -e, --email <email>     SHiFT account email (prompted if omitted)
   -p, --password <pw>     SHiFT account password (prompted if omitted)
       --shift-code <code> Redeem a single SHiFT code instead of the full list
-      --allow-inactive    Attempt to redeem inactive SHiFT codes too
+      --allow-inactive    Also attempt codes flagged as expired/inactive (v2 source)
       --v1                Force the original orcicorn code source
       --v2                Force the newer ugoogalizer/mentalmars code source
       --platform <list>   Comma-separated services to redeem on; default: all offered
@@ -261,7 +261,7 @@ func main() {
 	flag.StringVar(&password, "p", "", "SHiFT account password")
 	flag.StringVar(&password, "password", "", "SHiFT account password")
 	flag.StringVar(&singleShiftCode, "shift-code", "", "Redeem a single SHiFT code instead of the full list")
-	flag.BoolVar(&allowInactive, "allow-inactive", false, "Attempt to redeem inactive SHiFT codes too")
+	flag.BoolVar(&allowInactive, "allow-inactive", false, "Also attempt codes flagged as expired/inactive (v2 source)")
 	flag.BoolVar(&useV1, "v1", false, "Force the original orcicorn code source")
 	flag.BoolVar(&useV2, "v2", false, "Force the newer ugoogalizer/mentalmars code source")
 	flag.StringVar(&platform, "platform", "", "Comma-separated services to redeem on (default: all offered)")

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -20,6 +20,8 @@
 //	    --rampup            Cautious mode for a first run / long gap: pace requests,
 //	                        back off after 5 consecutive non-200s, stop after 20
 //	    --count <n>         Stop and save after n successful redemptions (0 = no limit)
+//	    --refresh           Re-query codes already redeemed on every linked platform
+//	                        (to pick up platforms linked since)
 //	    --migrate           Upgrade the redeemed-codes cache file in place and exit
 //	                        (no login); -e selects the per-account cache
 //	-v, --verbose           Verbose step-level logging to stderr
@@ -130,7 +132,8 @@ type shiftOptions struct {
 	platformFilter  []string
 	dryrun          bool
 	rampup          bool
-	count           int // stop after this many successful redemptions (0 = no limit)
+	refresh         bool // re-query codes marked complete (pick up newly-linked platforms)
+	count           int  // stop after this many successful redemptions (0 = no limit)
 }
 
 // cacheVersion is the current on-disk schema version of the redeemed-codes cache.
@@ -142,6 +145,35 @@ const cacheVersion = 2
 // entirely (no query, no redemption) on later runs. It is not a real service, so it
 // never matches a redemption form or a --platform filter.
 const expiredMarker = "expired"
+
+// completeMarker is recorded when a code has been redeemed on every platform the
+// SHiFT site offered for it (i.e. every linked platform). Such a code is skipped
+// without a query on later runs to cut request volume; --refresh re-queries it to
+// pick up platforms linked since. Like expiredMarker it is not a real service.
+const completeMarker = "complete"
+
+// markDone records a sentinel marker (expiredMarker/completeMarker) for a code,
+// avoiding duplicates.
+func markDone(m bl3.ShiftCodeMap, code, marker string) {
+	if !m.Contains(code, marker) {
+		m[code] = append(m[code], marker)
+	}
+}
+
+// allServicesRedeemed reports whether every service the site offered for a code is
+// recorded as redeemed — i.e. the code is complete for the currently-linked
+// platforms. Returns false when there are no forms.
+func allServicesRedeemed(m bl3.ShiftCodeMap, code string, forms []bl3.RedemptionForm) bool {
+	if len(forms) == 0 {
+		return false
+	}
+	for _, f := range forms {
+		if !m.Contains(code, f.Service) {
+			return false
+		}
+	}
+	return true
+}
 
 // redeemedCache is the versioned on-disk format of the redeemed-codes cache. Older
 // files are a bare ShiftCodeMap (no wrapper); readRedeemedCache reads both.
@@ -173,6 +205,8 @@ Flags:
                           requests, backs off after 5 consecutive non-200 responses,
                           and stops cleanly after 20 (likely rate-limit/shadowban)
       --count <n>         Stop and save after n successful redemptions (0 = no limit)
+      --refresh           Re-query codes already redeemed on every linked platform
+                          (use after linking a new platform on your SHiFT account)
       --migrate           Upgrade the redeemed-codes cache file in place to the
                           current version and exit (no login; -e selects the cache)
   -v, --verbose           Verbose step-level logging to stderr
@@ -379,9 +413,14 @@ codeLoop:
 	for _, sc := range codes {
 		code := sc.Code
 
-		// Codes already resolved as expired are terminal — skip them outright so we
-		// never spend a query (or a redemption) on them again.
+		// Skip codes we've already fully resolved, without spending a query:
+		// expired (terminal), or redeemed on every linked platform (complete).
+		// --refresh re-queries complete codes to detect newly-linked platforms;
+		// expired codes stay skipped regardless (they can never be redeemed again).
 		if redeemedCodes.Contains(code, expiredMarker) {
+			continue
+		}
+		if !opts.refresh && redeemedCodes.Contains(code, completeMarker) {
 			continue
 		}
 
@@ -423,7 +462,7 @@ codeLoop:
 			fmt.Println("'" + code + "': " + summarize(reason))
 			// An expired code is terminal: record it so it is never re-queried.
 			if strings.Contains(strings.ToLower(reason), "expired") {
-				redeemedCodes[code] = append(redeemedCodes[code], expiredMarker)
+				markDone(redeemedCodes, code, expiredMarker)
 			}
 			continue
 		}
@@ -464,7 +503,7 @@ codeLoop:
 				case strings.Contains(low, "expired"):
 					// Expiry is global and terminal: mark the whole code and stop
 					// trying its other platforms.
-					redeemedCodes[code] = append(redeemedCodes[code], expiredMarker)
+					markDone(redeemedCodes, code, expiredMarker)
 					break formLoop
 				case strings.Contains(low, "already"):
 					redeemedCodes[code] = append(redeemedCodes[code], form.Service)
@@ -478,6 +517,13 @@ codeLoop:
 					break codeLoop
 				}
 			}
+		}
+
+		// If the code is now redeemed on every platform the site offered (and we
+		// didn't filter any out with --platform), mark it complete so later runs
+		// skip the query entirely. Dry runs don't redeem, so they never complete.
+		if !opts.dryrun && allServicesRedeemed(redeemedCodes, code, forms) {
+			markDone(redeemedCodes, code, completeMarker)
 		}
 	}
 
@@ -535,6 +581,7 @@ func main() {
 		dryrun          bool
 		verbose         bool
 		rampup          bool
+		refresh         bool
 		migrate         bool
 		count           int
 	)
@@ -552,6 +599,7 @@ func main() {
 	flag.BoolVar(&dryrun, "dryrun", false, "Discover and match codes but do not redeem")
 	flag.BoolVar(&rampup, "rampup", false, "Cautious mode for a first run / long gap: pace requests and stop cleanly if throttled")
 	flag.IntVar(&count, "count", 0, "Stop and save after this many successful redemptions (0 = no limit)")
+	flag.BoolVar(&refresh, "refresh", false, "Re-query codes already redeemed on every linked platform (to pick up newly-linked platforms)")
 	flag.BoolVar(&migrate, "migrate", false, "Upgrade the redeemed-codes cache file in place to the current version and exit (no login)")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose step-level logging to stderr")
 	flag.BoolVar(&verbose, "v", false, "Verbose step-level logging to stderr")
@@ -630,6 +678,7 @@ func main() {
 		platformFilter:  platformFilter,
 		dryrun:          dryrun,
 		rampup:          rampup,
+		refresh:         refresh,
 		count:           count,
 	})
 

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -52,14 +52,23 @@ var (
 	rateLimitRetries  = 5                      // give up (stop the run) after this many
 )
 
-// withBackoff runs op, retrying with exponential backoff while it reports
-// ErrRateLimited. It returns the final error and stop=true when the rate limit
-// persisted past rateLimitRetries, signalling the caller to halt the run.
-func withBackoff(op func() error) (err error, stop bool) {
+// bulkThreshold is the candidate-code count at or above which a run is treated
+// as "bulk": only then do we pace requests and back off on rate limits. A
+// single --shift-code redemption stays fast and un-throttled.
+const bulkThreshold = 5
+
+// withBackoff runs op. When retry is true and op reports ErrRateLimited, it
+// retries with exponential backoff and returns stop=true if the limit persists
+// past rateLimitRetries (the caller should then halt the run). When retry is
+// false (small/non-bulk runs) a rate-limit error is returned as-is.
+func withBackoff(retry bool, op func() error) (err error, stop bool) {
 	wait := rateLimitBaseWait
 	for attempt := 1; ; attempt++ {
 		err = op()
 		if err == nil || !errors.Is(err, bl3.ErrRateLimited) {
+			return err, false
+		}
+		if !retry {
 			return err, false
 		}
 		if attempt > rateLimitRetries {
@@ -158,26 +167,42 @@ func summarize(s string) string {
 	return joined
 }
 
-func loadRedeemedCodes(configDirs configdir.ConfigDir, configFilename string) bl3.ShiftCodeMap {
+// readRedeemedCodes parses the previously-redeemed-codes cache from a config
+// folder — the directory the Docker `codes/` volume maps onto. A nil folder
+// (no cache dir yet) or an unreadable/empty file yields an empty map.
+func readRedeemedCodes(folder *configdir.Config, configFilename string) bl3.ShiftCodeMap {
 	redeemedCodes := bl3.ShiftCodeMap{}
-	fmt.Print("Getting previously redeemed SHIFT codes . . . . . ")
-	folder := configDirs.QueryFolderContainsFile(configFilename)
 	if folder == nil {
-		fmt.Println(NOTFOUND)
 		return redeemedCodes
 	}
 	data, err := folder.ReadFile(configFilename)
 	if err != nil {
-		fmt.Println(NOTFOUND)
 		return redeemedCodes
 	}
 	if j := bl3.JsonFromBytes(data); j != nil {
 		j.Out(&redeemedCodes)
-		fmt.Println(SUCCESS)
-	} else {
-		fmt.Println(NOTFOUND)
 	}
 	return redeemedCodes
+}
+
+// writeRedeemedCodes persists the redeemed-codes cache to a config folder.
+func writeRedeemedCodes(folder *configdir.Config, configFilename string, redeemedCodes bl3.ShiftCodeMap) error {
+	data, err := json.MarshalIndent(&redeemedCodes, "", "  ")
+	if err != nil {
+		return err
+	}
+	return folder.WriteFile(configFilename, data)
+}
+
+func loadRedeemedCodes(configDirs configdir.ConfigDir, configFilename string) bl3.ShiftCodeMap {
+	fmt.Print("Getting previously redeemed SHIFT codes . . . . . ")
+	folder := configDirs.QueryFolderContainsFile(configFilename)
+	if folder == nil {
+		fmt.Println(NOTFOUND)
+		return bl3.ShiftCodeMap{}
+	}
+	fmt.Println(SUCCESS)
+	return readRedeemedCodes(folder, configFilename)
 }
 
 func doShift(client *bl3.Bl3Client, opts shiftOptions) {
@@ -206,6 +231,13 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 		fmt.Println(SUCCESS)
 	}
 
+	// Only pace requests and back off on rate limits for bulk runs; a single
+	// (or handful of) code(s) stays fast and un-throttled.
+	bulk := len(codes) >= bulkThreshold
+	if bulk {
+		client.SetThrottle(throttleBase, throttleJitter)
+	}
+
 	redeemedAny := false
 	cacheDirty := false
 	rateLimited := false
@@ -216,7 +248,7 @@ codeLoop:
 
 		var forms []bl3.RedemptionForm
 		var reason string
-		err, stop := withBackoff(func() error {
+		err, stop := withBackoff(bulk, func() error {
 			var e error
 			forms, reason, e = client.GetCodeRedemptionForms(code)
 			return e
@@ -253,7 +285,7 @@ codeLoop:
 			}
 
 			fmt.Print("Trying '" + form.Service + "' SHIFT code '" + code + DOTDOTDOT)
-			rerr, stop := withBackoff(func() error { return client.RedeemForm(form) })
+			rerr, stop := withBackoff(bulk, func() error { return client.RedeemForm(form) })
 			if stop {
 				fmt.Println("rate limited.")
 				rateLimited = true
@@ -287,11 +319,8 @@ codeLoop:
 
 	if cacheDirty && !opts.dryrun {
 		folders := configDirs.QueryFolders(configdir.Global)
-		data, err := json.MarshalIndent(&redeemedCodes, "", "  ")
-		if err == nil {
-			if werr := folders[0].WriteFile(configFilename, data); werr != nil {
-				printError(werr)
-			}
+		if err := writeRedeemedCodes(folders[0], configFilename, redeemedCodes); err != nil {
+			printError(err)
 		}
 	}
 }
@@ -372,7 +401,6 @@ func main() {
 	}
 	client.Verbose = verbose
 	client.Config.Shift.AllowInactive = allowInactive
-	client.SetThrottle(throttleBase, throttleJitter)
 	fmt.Println(SUCCESS)
 
 	if client.Config.Version != version {

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -41,7 +41,7 @@ import (
 )
 
 // gross but effective for now
-const version = "2.2.28"
+const version = "2.3.0"
 
 const SUCCESS = "success!"
 const NOTFOUND = "not found."

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -84,6 +84,18 @@ var (
 	rampupThrottleJitter = 1500 * time.Millisecond
 )
 
+// Adaptive (AIMD) throttle. On a bulk run the request spacing self-tunes to the
+// rate SHiFT tolerates: it widens multiplicatively on each non-200 code query (a
+// throttle signal) up to throttleCeil, and narrows by throttleSpeedup after every
+// throttleSpeedupAfter clean queries, never below the configured base. All vars so
+// tests can shrink them.
+var (
+	throttleCeil         = 8 * time.Second
+	throttleSlowFactor   = 1.5
+	throttleSpeedup      = 200 * time.Millisecond
+	throttleSpeedupAfter = 8
+)
+
 // bulkThreshold is the candidate-code count at or above which a run is treated
 // as "bulk": only then do we pace requests and back off on rate limits. A
 // single --shift-code redemption stays fast and un-throttled.
@@ -524,6 +536,7 @@ func doShift(ctx context.Context, client *bl3.Bl3Client, opts shiftOptions) {
 	reachedCount := false
 	interrupted := false
 	consecutive := 0  // consecutive non-200 code-query responses (see --rampup)
+	cleanStreak := 0  // consecutive clean (200) code queries (drives adaptive speed-up)
 	successCount := 0 // new successful redemptions this run (see --count)
 
 codeLoop:
@@ -569,6 +582,14 @@ codeLoop:
 		var statusErr *bl3.CodeQueryStatusError
 		if errors.As(err, &statusErr) {
 			consecutive++
+			cleanStreak = 0
+			if bulk {
+				// AIMD: ease off the pace so the run self-tunes to a sustainable rate.
+				client.Slowdown(throttleSlowFactor, throttleCeil)
+				if client.Verbose {
+					_, _ = fmt.Fprintf(os.Stderr, "[verbose] non-200 query; throttle now %s\n", client.CurrentInterval())
+				}
+			}
 			fmt.Println("Skipping '" + code + "': " + err.Error())
 			if bulk && consecutive >= stopAfter {
 				stoppedShadowban = true
@@ -589,6 +610,17 @@ codeLoop:
 			continue
 		}
 		consecutive = 0
+		if bulk {
+			// AIMD: a clean streak means we can cautiously speed back up.
+			cleanStreak++
+			if cleanStreak >= throttleSpeedupAfter {
+				client.Speedup(throttleSpeedup)
+				if client.Verbose {
+					_, _ = fmt.Fprintf(os.Stderr, "[verbose] clean streak; throttle now %s\n", client.CurrentInterval())
+				}
+				cleanStreak = 0
+			}
+		}
 		if len(forms) == 0 {
 			fmt.Println("'" + code + "': " + summarize(reason))
 			// An expired code is terminal: record it so it is never re-queried.

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -19,6 +19,8 @@
 //	    --dryrun            Discover and match codes but do not redeem (no side effects)
 //	    --rampup            Cautious mode for a first run / long gap: pace requests,
 //	                        back off after 5 consecutive non-200s, stop after 20
+//	    --migrate           Upgrade the redeemed-codes cache file in place and exit
+//	                        (no login); -e selects the per-account cache
 //	-v, --verbose           Verbose step-level logging to stderr
 //	-h, --help              Show this help
 //
@@ -155,6 +157,8 @@ Flags:
       --rampup            Cautious mode for a first run or after a long gap: paces
                           requests, backs off after 5 consecutive non-200 responses,
                           and stops cleanly after 20 (likely rate-limit/shadowban)
+      --migrate           Upgrade the redeemed-codes cache file in place to the
+                          current version and exit (no login; -e selects the cache)
   -v, --verbose           Verbose step-level logging to stderr
   -h, --help              Show this help
 
@@ -268,6 +272,39 @@ func rampupAdvised(existed bool, lastRun, now time.Time) bool {
 		return true
 	}
 	return lastRun.Before(now.AddDate(0, -6, 0))
+}
+
+// runMigrate upgrades the redeemed-codes cache file in place to the current versioned
+// format. It is a standalone, login-free maintenance op (--migrate): it reads the
+// existing file (including the old bare-map format), preserves its codes and last-run
+// time, and rewrites it as {version, lastRun, codes}. lastRun is intentionally left
+// untouched (zero for an old file) so the stale-run warning still fires for long-absent
+// users. Already-current files are left as-is.
+func runMigrate() {
+	folder := resolveCacheFolder()
+	configFilename := usernameHash + "-shift-codes.json"
+	if folder == nil {
+		fmt.Println("No cache folder available; nothing to migrate.")
+		return
+	}
+
+	data, err := folder.ReadFile(configFilename)
+	if err != nil {
+		fmt.Println("No redeemed-codes cache to migrate.")
+		return
+	}
+	var existing redeemedCache
+	if json.Unmarshal(data, &existing) == nil && existing.Codes != nil && existing.Version == cacheVersion {
+		fmt.Printf("Cache is already version %d (nothing to do).\n", cacheVersion)
+		return
+	}
+
+	codes, lastRun, _ := readRedeemedCache(folder, configFilename)
+	if err := writeRedeemedCache(folder, configFilename, codes, lastRun); err != nil {
+		printError(err)
+		return
+	}
+	fmt.Printf("Migrated %d codes to cache version %d (in place).\n", len(codes), cacheVersion)
 }
 
 func doShift(client *bl3.Bl3Client, opts shiftOptions) {
@@ -456,6 +493,7 @@ func main() {
 		dryrun          bool
 		verbose         bool
 		rampup          bool
+		migrate         bool
 	)
 
 	flag.StringVar(&username, "e", "", "SHiFT account email")
@@ -470,6 +508,7 @@ func main() {
 	flag.StringVar(&configPath, "config", "", "Use a local config.json instead of the published remote config")
 	flag.BoolVar(&dryrun, "dryrun", false, "Discover and match codes but do not redeem")
 	flag.BoolVar(&rampup, "rampup", false, "Cautious mode for a first run / long gap: pace requests and stop cleanly if throttled")
+	flag.BoolVar(&migrate, "migrate", false, "Upgrade the redeemed-codes cache file in place to the current version and exit (no login)")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose step-level logging to stderr")
 	flag.BoolVar(&verbose, "v", false, "Verbose step-level logging to stderr")
 	flag.Usage = usage
@@ -501,17 +540,24 @@ func main() {
 		line, _, _ := reader.ReadLine()
 		username = string(line)
 	}
+
+	// SHA256 Hash (selects the per-account redeemed-codes cache file).
+	hasher := sha256.New()
+	hasher.Write([]byte(username))
+	usernameHash = hex.EncodeToString(hasher.Sum(nil))
+
+	// --migrate is a standalone, login-free maintenance op: just upgrade the cache.
+	if migrate {
+		runMigrate()
+		return
+	}
+
 	if password == "" {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Enter password        : ")
 		line, _, _ := reader.ReadLine()
 		password = string(line)
 	}
-
-	// SHA256 Hash
-	hasher := sha256.New()
-	hasher.Write([]byte(username))
-	usernameHash = hex.EncodeToString(hasher.Sum(nil))
 
 	fmt.Print("Setting up . . . . . ")
 	client, err := bl3.NewBl3Client(configPath)

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -59,7 +59,7 @@ type shiftOptions struct {
 
 func usage() {
 	out := flag.CommandLine.Output()
-	fmt.Fprintf(out, `bl3auto - automatically redeem Gearbox SHiFT codes
+	_, _ = fmt.Fprintf(out, `bl3auto - automatically redeem Gearbox SHiFT codes
 
 Usage:
   bl3auto [flags]

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -19,6 +19,7 @@
 //	    --dryrun            Discover and match codes but do not redeem (no side effects)
 //	    --rampup            Cautious mode for a first run / long gap: pace requests,
 //	                        back off after 5 consecutive non-200s, stop after 20
+//	    --count <n>         Stop and save after n successful redemptions (0 = no limit)
 //	    --migrate           Upgrade the redeemed-codes cache file in place and exit
 //	                        (no login); -e selects the per-account cache
 //	-v, --verbose           Verbose step-level logging to stderr
@@ -75,9 +76,16 @@ var (
 // single --shift-code redemption stays fast and un-throttled.
 const bulkThreshold = 5
 
-// resolveCacheFolder returns the folder that stores the redeemed-codes cache —
-// the directory the Docker `codes/` volume maps onto. Overridable in tests.
+// resolveCacheFolder returns the folder that stores the redeemed-codes cache.
+// It prefers a local `codes/` directory in the working directory when one exists —
+// the same path the Docker image mounts its volume onto — so a native run from the
+// project directory shares the cache instead of writing to the OS config dir. When
+// no local `codes/` exists it falls back to the per-user config dir. Overridable in
+// tests.
 var resolveCacheFolder = func() *configdir.Config {
+	if fi, err := os.Stat("codes"); err == nil && fi.IsDir() {
+		return &configdir.Config{Path: "codes", Type: configdir.Local}
+	}
 	return configdir.New("bl3auto", "bl3auto").QueryFolders(configdir.Global)[0]
 }
 
@@ -122,11 +130,18 @@ type shiftOptions struct {
 	platformFilter  []string
 	dryrun          bool
 	rampup          bool
+	count           int // stop after this many successful redemptions (0 = no limit)
 }
 
 // cacheVersion is the current on-disk schema version of the redeemed-codes cache.
 // Bump it when the layout changes so future migrations can branch on it.
 const cacheVersion = 2
+
+// expiredMarker is recorded in a code's cache entry when SHiFT reports the code as
+// expired. Expiry is terminal and platform-independent, so a marked code is skipped
+// entirely (no query, no redemption) on later runs. It is not a real service, so it
+// never matches a redemption form or a --platform filter.
+const expiredMarker = "expired"
 
 // redeemedCache is the versioned on-disk format of the redeemed-codes cache. Older
 // files are a bare ShiftCodeMap (no wrapper); readRedeemedCache reads both.
@@ -157,6 +172,7 @@ Flags:
       --rampup            Cautious mode for a first run or after a long gap: paces
                           requests, backs off after 5 consecutive non-200 responses,
                           and stops cleanly after 20 (likely rate-limit/shadowban)
+      --count <n>         Stop and save after n successful redemptions (0 = no limit)
       --migrate           Upgrade the redeemed-codes cache file in place to the
                           current version and exit (no login; -e selects the cache)
   -v, --verbose           Verbose step-level logging to stderr
@@ -355,11 +371,19 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 	redeemedAny := false
 	rateLimited := false
 	stoppedShadowban := false
-	consecutive := 0 // consecutive non-200 code-query responses (see --rampup)
+	reachedCount := false
+	consecutive := 0  // consecutive non-200 code-query responses (see --rampup)
+	successCount := 0 // new successful redemptions this run (see --count)
 
 codeLoop:
 	for _, sc := range codes {
 		code := sc.Code
+
+		// Codes already resolved as expired are terminal — skip them outright so we
+		// never spend a query (or a redemption) on them again.
+		if redeemedCodes.Contains(code, expiredMarker) {
+			continue
+		}
 
 		var forms []bl3.RedemptionForm
 		var reason string
@@ -397,12 +421,17 @@ codeLoop:
 		consecutive = 0
 		if len(forms) == 0 {
 			fmt.Println("'" + code + "': " + summarize(reason))
+			// An expired code is terminal: record it so it is never re-queried.
+			if strings.Contains(strings.ToLower(reason), "expired") {
+				redeemedCodes[code] = append(redeemedCodes[code], expiredMarker)
+			}
 			continue
 		}
 
 		// One redemption per form: the SHiFT site returns a form for each platform
 		// linked to the account, so a code is redeemed once per linked platform
 		// (--platform narrows this set).
+	formLoop:
 		for _, form := range forms {
 			if !bl3.ServiceMatches(opts.platformFilter, form.Service) {
 				continue
@@ -431,17 +460,30 @@ codeLoop:
 			if rerr != nil {
 				fmt.Println(rerr)
 				low := strings.ToLower(rerr.Error())
-				if strings.Contains(low, "already") || strings.Contains(low, "expired") {
+				switch {
+				case strings.Contains(low, "expired"):
+					// Expiry is global and terminal: mark the whole code and stop
+					// trying its other platforms.
+					redeemedCodes[code] = append(redeemedCodes[code], expiredMarker)
+					break formLoop
+				case strings.Contains(low, "already"):
 					redeemedCodes[code] = append(redeemedCodes[code], form.Service)
 				}
 			} else {
 				redeemedCodes[code] = append(redeemedCodes[code], form.Service)
 				fmt.Println(SUCCESS)
+				successCount++
+				if opts.count > 0 && successCount >= opts.count {
+					reachedCount = true
+					break codeLoop
+				}
 			}
 		}
 	}
 
 	switch {
+	case reachedCount:
+		fmt.Printf("Reached the --count limit of %d successful redemption(s). Progress saved; re-run to continue.\n", opts.count)
 	case stoppedShadowban:
 		fmt.Printf("Stopped after %d consecutive non-200 responses (likely rate-limited/shadowbanned by SHiFT).\n", consecutive)
 		fmt.Println("Progress saved; wait a while and re-run with --rampup to continue.")
@@ -494,6 +536,7 @@ func main() {
 		verbose         bool
 		rampup          bool
 		migrate         bool
+		count           int
 	)
 
 	flag.StringVar(&username, "e", "", "SHiFT account email")
@@ -508,6 +551,7 @@ func main() {
 	flag.StringVar(&configPath, "config", "", "Use a local config.json instead of the published remote config")
 	flag.BoolVar(&dryrun, "dryrun", false, "Discover and match codes but do not redeem")
 	flag.BoolVar(&rampup, "rampup", false, "Cautious mode for a first run / long gap: pace requests and stop cleanly if throttled")
+	flag.IntVar(&count, "count", 0, "Stop and save after this many successful redemptions (0 = no limit)")
 	flag.BoolVar(&migrate, "migrate", false, "Upgrade the redeemed-codes cache file in place to the current version and exit (no login)")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose step-level logging to stderr")
 	flag.BoolVar(&verbose, "v", false, "Verbose step-level logging to stderr")
@@ -586,6 +630,7 @@ func main() {
 		platformFilter:  platformFilter,
 		dryrun:          dryrun,
 		rampup:          rampup,
+		count:           count,
 	})
 
 	exit()

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -1,3 +1,27 @@
+// Command bl3auto automatically redeems Gearbox SHiFT codes for the Borderlands
+// and Wonderlands games against your SHiFT account (https://shift.gearboxsoftware.com).
+//
+// Usage:
+//
+//	bl3auto [flags]
+//
+// Flags:
+//
+//	-e, --email <email>     SHiFT account email (prompted if omitted)
+//	-p, --password <pw>     SHiFT account password (prompted if omitted)
+//	    --shift-code <code> Redeem a single SHiFT code instead of the full list
+//	    --allow-inactive    Attempt to redeem inactive SHiFT codes too
+//	    --v1                Force the original orcicorn code source
+//	    --v2                Force the newer ugoogalizer/mentalmars code source
+//	    --platform <list>   Comma-separated services to redeem on
+//	                        (steam,epic,psn,xboxlive,nintendo,stadia); default: all offered
+//	    --config <path>     Use a local config.json instead of the published remote config
+//	    --dryrun            Discover and match codes but do not redeem (no side effects)
+//	-v, --verbose           Verbose step-level logging to stderr
+//	-h, --help              Show this help
+//
+// By default the newer (v2) code source is used and the tool falls back to the
+// original (v1) source only if v2 is unavailable. --v1/--v2 force a single source.
 package main
 
 import (
@@ -25,6 +49,54 @@ const DOTDOTDOT = "' . . . . . "
 
 var usernameHash string
 
+// shiftOptions carries the resolved CLI options into the redemption routine.
+type shiftOptions struct {
+	source          string // "v1", "v2", or "" for default failover
+	singleShiftCode string
+	platformFilter  []string
+	dryrun          bool
+}
+
+func usage() {
+	out := flag.CommandLine.Output()
+	fmt.Fprintf(out, `bl3auto - automatically redeem Gearbox SHiFT codes
+
+Usage:
+  bl3auto [flags]
+
+Flags:
+  -e, --email <email>     SHiFT account email (prompted if omitted)
+  -p, --password <pw>     SHiFT account password (prompted if omitted)
+      --shift-code <code> Redeem a single SHiFT code instead of the full list
+      --allow-inactive    Attempt to redeem inactive SHiFT codes too
+      --v1                Force the original orcicorn code source
+      --v2                Force the newer ugoogalizer/mentalmars code source
+      --platform <list>   Comma-separated services to redeem on; default: all offered
+                          (valid: steam, epic, psn, xboxlive, nintendo, stadia)
+      --config <path>     Use a local config.json instead of the published remote config
+      --dryrun            Discover and match codes but do not redeem (no side effects)
+  -v, --verbose           Verbose step-level logging to stderr
+  -h, --help              Show this help
+
+Code source:
+  By default the newer (v2) source is used, falling back to the original (v1)
+  source only if v2 is unavailable. Use --v1 or --v2 to force a single source.
+
+Examples:
+  # Redeem all current codes for every linked platform
+  bl3auto -e you@example.com -p 'secret'
+
+  # See what would be redeemed without redeeming anything
+  bl3auto -e you@example.com -p 'secret' --dryrun -v
+
+  # Redeem a single code on Steam only
+  bl3auto -e you@example.com -p 'secret' --shift-code ABCDE-... --platform steam
+
+  # Force the original (v1) code source
+  bl3auto -e you@example.com -p 'secret' --v1
+`)
+}
+
 func printError(err error) {
 	fmt.Println("failed!")
 	fmt.Print("Had error: ")
@@ -40,130 +112,197 @@ func exit() {
 	fmt.Println("")
 }
 
-func doShift(client *bl3.Bl3Client, singleShiftCode string) {
-	fmt.Print("Getting SHIFT platforms . . . . . ")
-	platforms, err := client.GetShiftPlatforms()
-	if err != nil {
-		printError(err)
-		return
+// summarize collapses whitespace and truncates a (possibly HTML-derived) status
+// message to a single readable line.
+func summarize(s string) string {
+	joined := strings.Join(strings.Fields(s), " ")
+	if joined == "" {
+		return "not redeemable"
 	}
-	fmt.Println(SUCCESS)
+	if len(joined) > 160 {
+		return joined[:160] + "..."
+	}
+	return joined
+}
 
-	configDirs := configdir.New("bl3auto", "bl3auto")
-	configFilename := usernameHash + "-shift-codes.json"
+func loadRedeemedCodes(configDirs configdir.ConfigDir, configFilename string) bl3.ShiftCodeMap {
 	redeemedCodes := bl3.ShiftCodeMap{}
-
 	fmt.Print("Getting previously redeemed SHIFT codes . . . . . ")
 	folder := configDirs.QueryFolderContainsFile(configFilename)
-	if folder != nil {
-		data, err := folder.ReadFile(configFilename)
-		if err == nil {
-			json := bl3.JsonFromBytes(data)
-			if json != nil {
-				json.Out(&redeemedCodes)
-				fmt.Println(SUCCESS)
-			} else {
-				fmt.Println(NOTFOUND)
-			}
-		} else {
-			fmt.Println(NOTFOUND)
-		}
+	if folder == nil {
+		fmt.Println(NOTFOUND)
+		return redeemedCodes
+	}
+	data, err := folder.ReadFile(configFilename)
+	if err != nil {
+		fmt.Println(NOTFOUND)
+		return redeemedCodes
+	}
+	if j := bl3.JsonFromBytes(data); j != nil {
+		j.Out(&redeemedCodes)
+		fmt.Println(SUCCESS)
 	} else {
 		fmt.Println(NOTFOUND)
 	}
+	return redeemedCodes
+}
 
-	shiftCodes := bl3.ShiftCodeMap{}
+func doShift(client *bl3.Bl3Client, opts shiftOptions) {
+	configDirs := configdir.New("bl3auto", "bl3auto")
+	configFilename := usernameHash + "-shift-codes.json"
+	redeemedCodes := loadRedeemedCodes(configDirs, configFilename)
 
-	if singleShiftCode != "" {
-		singleShiftCode = strings.TrimSpace(strings.ToUpper(singleShiftCode))
-		fmt.Print("Checking single SHIFT code '" + singleShiftCode + DOTDOTDOT)
-		platforms, valid := client.GetCodePlatforms(singleShiftCode)
-		if valid {
-			shiftCodes[singleShiftCode] = platforms
-			fmt.Println(SUCCESS)
-		} else {
-			fmt.Println("no available redemption platforms found!")
-		}
+	// Gather the candidate codes: a single code, or the full list from the source.
+	var codes []bl3.ShiftCode
+	if opts.singleShiftCode != "" {
+		code := strings.TrimSpace(strings.ToUpper(opts.singleShiftCode))
+		codes = []bl3.ShiftCode{{Code: code}}
+		fmt.Println("Checking single SHIFT code '" + code + "'")
 	} else {
-		fmt.Print("Getting new SHIFT codes . . . . . ")
-		allShiftCodes, err := client.GetFullShiftCodeList()
+		label := "Getting new SHIFT codes"
+		if opts.source != "" {
+			label += " (" + opts.source + ")"
+		}
+		fmt.Print(label + " . . . . . ")
+		list, err := client.GetShiftCodes(opts.source)
 		if err != nil {
 			printError(err)
 			return
 		}
-		shiftCodes = allShiftCodes
+		codes = list
 		fmt.Println(SUCCESS)
 	}
 
-	foundCodes := false
-	for code, codePlatforms := range shiftCodes {
-		for _, platform := range codePlatforms {
-			if _, found := platforms[platform]; found {
-				if !redeemedCodes.Contains(code, platform) {
-					foundCodes = true
-					fmt.Print("Trying '" + platform + "' SHIFT code '" + code + DOTDOTDOT)
-					err := client.RedeemShiftCode(code, platform)
-					if err != nil {
-						fmt.Println(err)
-						if strings.Contains(strings.ToLower(err.Error()), "already") {
-							redeemedCodes[code] = append(redeemedCodes[code], platform)
-						} else if strings.Contains(strings.ToLower(err.Error()), "has expired") {
-							redeemedCodes[code] = append(redeemedCodes[code], platform)
-						}
-					} else {
-						redeemedCodes[code] = append(redeemedCodes[code], platform)
-						fmt.Println(SUCCESS)
-					}
-				} else if singleShiftCode != "" {
-					fmt.Println("The single SHIFT code has already been redeemed on the '" + platform + "' platform")
-					foundCodes = true
+	redeemedAny := false
+	cacheDirty := false
+
+	for _, sc := range codes {
+		code := sc.Code
+		forms, reason, err := client.GetCodeRedemptionForms(code)
+		if err != nil {
+			fmt.Println("Skipping '" + code + "': " + err.Error())
+			continue
+		}
+		if len(forms) == 0 {
+			fmt.Println("'" + code + "': " + summarize(reason))
+			continue
+		}
+
+		for _, form := range forms {
+			if !bl3.ServiceMatches(opts.platformFilter, form.Service) {
+				continue
+			}
+			if redeemedCodes.Contains(code, form.Service) {
+				if opts.singleShiftCode != "" {
+					fmt.Println("The single SHIFT code has already been redeemed on the '" + form.Service + "' platform")
+					redeemedAny = true
 				}
+				continue
+			}
+
+			redeemedAny = true
+			if opts.dryrun {
+				fmt.Println("[dryrun] would redeem '" + form.Service + "' SHIFT code '" + code + "'")
+				continue
+			}
+
+			fmt.Print("Trying '" + form.Service + "' SHIFT code '" + code + DOTDOTDOT)
+			if rerr := client.RedeemForm(form); rerr != nil {
+				fmt.Println(rerr)
+				low := strings.ToLower(rerr.Error())
+				if strings.Contains(low, "already") || strings.Contains(low, "expired") {
+					redeemedCodes[code] = append(redeemedCodes[code], form.Service)
+					cacheDirty = true
+				}
+			} else {
+				redeemedCodes[code] = append(redeemedCodes[code], form.Service)
+				cacheDirty = true
+				fmt.Println(SUCCESS)
 			}
 		}
 	}
 
-	if !foundCodes && singleShiftCode != "" {
-		fmt.Println("The single SHIFT code could not be redeemed at this time. Try again later.")
-	} else if !foundCodes {
-		fmt.Println("No new SHIFT codes at this time. Try again later.")
-	} else {
+	if !redeemedAny {
+		if opts.singleShiftCode != "" {
+			fmt.Println("The single SHIFT code could not be redeemed at this time. Try again later.")
+		} else {
+			fmt.Println("No new SHIFT codes at this time. Try again later.")
+		}
+		return
+	}
+
+	if cacheDirty && !opts.dryrun {
 		folders := configDirs.QueryFolders(configdir.Global)
 		data, err := json.MarshalIndent(&redeemedCodes, "", "  ")
 		if err == nil {
-			err := folders[0].WriteFile(configFilename, data)
-			if err != nil {
-				printError(err)
-				return
+			if werr := folders[0].WriteFile(configFilename, data); werr != nil {
+				printError(werr)
 			}
 		}
 	}
-
 }
 
 func main() {
-	username := ""
-	password := ""
-	singleShiftCode := ""
-	allowInactive := false
-	flag.StringVar(&username, "e", "", "Email")
-	flag.StringVar(&username, "email", "", "Email")
-	flag.StringVar(&password, "p", "", "Password")
-	flag.StringVar(&password, "password", "", "Password")
-	flag.StringVar(&singleShiftCode, "shift-code", "", "Single SHIFT code to redeem")
-	flag.BoolVar(&allowInactive, "allow-inactive", false, "Attempt to redeem SHIFT codes even if they are inactive?")
+	var (
+		username        string
+		password        string
+		singleShiftCode string
+		allowInactive   bool
+		useV1           bool
+		useV2           bool
+		platform        string
+		configPath      string
+		dryrun          bool
+		verbose         bool
+	)
+
+	flag.StringVar(&username, "e", "", "SHiFT account email")
+	flag.StringVar(&username, "email", "", "SHiFT account email")
+	flag.StringVar(&password, "p", "", "SHiFT account password")
+	flag.StringVar(&password, "password", "", "SHiFT account password")
+	flag.StringVar(&singleShiftCode, "shift-code", "", "Redeem a single SHiFT code instead of the full list")
+	flag.BoolVar(&allowInactive, "allow-inactive", false, "Attempt to redeem inactive SHiFT codes too")
+	flag.BoolVar(&useV1, "v1", false, "Force the original orcicorn code source")
+	flag.BoolVar(&useV2, "v2", false, "Force the newer ugoogalizer/mentalmars code source")
+	flag.StringVar(&platform, "platform", "", "Comma-separated services to redeem on (default: all offered)")
+	flag.StringVar(&configPath, "config", "", "Use a local config.json instead of the published remote config")
+	flag.BoolVar(&dryrun, "dryrun", false, "Discover and match codes but do not redeem")
+	flag.BoolVar(&verbose, "verbose", false, "Verbose step-level logging to stderr")
+	flag.BoolVar(&verbose, "v", false, "Verbose step-level logging to stderr")
+	flag.Usage = usage
 	flag.Parse()
+
+	if useV1 && useV2 {
+		fmt.Println("error: --v1 and --v2 are mutually exclusive")
+		flag.Usage()
+		os.Exit(2)
+	}
+	source := ""
+	switch {
+	case useV1:
+		source = "v1"
+	case useV2:
+		source = "v2"
+	}
+
+	var platformFilter []string
+	for p := range strings.SplitSeq(platform, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			platformFilter = append(platformFilter, t)
+		}
+	}
 
 	if username == "" {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Enter username (email): ")
-		bytes, _, _ := reader.ReadLine()
-		username = string(bytes)
+		line, _, _ := reader.ReadLine()
+		username = string(line)
 	}
 	if password == "" {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Enter password        : ")
-		bytes, _, _ := reader.ReadLine()
-		password = string(bytes)
+		line, _, _ := reader.ReadLine()
+		password = string(line)
 	}
 
 	// SHA256 Hash
@@ -172,14 +311,13 @@ func main() {
 	usernameHash = hex.EncodeToString(hasher.Sum(nil))
 
 	fmt.Print("Setting up . . . . . ")
-	client, err := bl3.NewBl3Client()
+	client, err := bl3.NewBl3Client(configPath)
 	if err != nil {
 		printError(err)
 		return
 	}
-
+	client.Verbose = verbose
 	client.Config.Shift.AllowInactive = allowInactive
-
 	fmt.Println(SUCCESS)
 
 	if client.Config.Version != version {
@@ -187,14 +325,18 @@ func main() {
 	}
 
 	fmt.Print("Logging in as '" + username + DOTDOTDOT)
-	err = client.Login(username, password)
-	if err != nil {
+	if err = client.Login(username, password); err != nil {
 		printError(err)
 		return
 	}
 	fmt.Println(SUCCESS)
 
-	doShift(client, singleShiftCode)
+	doShift(client, shiftOptions{
+		source:          source,
+		singleShiftCode: singleShiftCode,
+		platformFilter:  platformFilter,
+		dryrun:          dryrun,
+	})
 
 	exit()
 }

--- a/cmd/bl3auto.go
+++ b/cmd/bl3auto.go
@@ -29,6 +29,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -39,6 +40,38 @@ import (
 	bl3 "github.com/jauderho/bl3auto"
 	"github.com/shibukawa/configdir"
 )
+
+// Request pacing and rate-limit backoff (sensible defaults; not user-tunable).
+// Spacing requests and backing off on HTTP 429/503 lets us redeem in bulk
+// without tripping SHiFT's rate limits or risking a ban.
+var (
+	throttleBase      = 400 * time.Millisecond // minimum spacing between SHiFT requests
+	throttleJitter    = 400 * time.Millisecond // added random spacing (0..jitter)
+	rateLimitBaseWait = 2 * time.Second        // first backoff on a 429/503
+	rateLimitMaxWait  = 30 * time.Second       // backoff ceiling
+	rateLimitRetries  = 5                      // give up (stop the run) after this many
+)
+
+// withBackoff runs op, retrying with exponential backoff while it reports
+// ErrRateLimited. It returns the final error and stop=true when the rate limit
+// persisted past rateLimitRetries, signalling the caller to halt the run.
+func withBackoff(op func() error) (err error, stop bool) {
+	wait := rateLimitBaseWait
+	for attempt := 1; ; attempt++ {
+		err = op()
+		if err == nil || !errors.Is(err, bl3.ErrRateLimited) {
+			return err, false
+		}
+		if attempt > rateLimitRetries {
+			return err, true
+		}
+		fmt.Printf("Rate limited by SHiFT; backing off %s (retry %d/%d) . . .\n", wait, attempt, rateLimitRetries)
+		time.Sleep(wait)
+		if wait *= 2; wait > rateLimitMaxWait {
+			wait = rateLimitMaxWait
+		}
+	}
+}
 
 // gross but effective for now
 const version = "2.3.0"
@@ -175,10 +208,23 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 
 	redeemedAny := false
 	cacheDirty := false
+	rateLimited := false
 
+codeLoop:
 	for _, sc := range codes {
 		code := sc.Code
-		forms, reason, err := client.GetCodeRedemptionForms(code)
+
+		var forms []bl3.RedemptionForm
+		var reason string
+		err, stop := withBackoff(func() error {
+			var e error
+			forms, reason, e = client.GetCodeRedemptionForms(code)
+			return e
+		})
+		if stop {
+			rateLimited = true
+			break codeLoop
+		}
 		if err != nil {
 			fmt.Println("Skipping '" + code + "': " + err.Error())
 			continue
@@ -207,7 +253,13 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 			}
 
 			fmt.Print("Trying '" + form.Service + "' SHIFT code '" + code + DOTDOTDOT)
-			if rerr := client.RedeemForm(form); rerr != nil {
+			rerr, stop := withBackoff(func() error { return client.RedeemForm(form) })
+			if stop {
+				fmt.Println("rate limited.")
+				rateLimited = true
+				break codeLoop
+			}
+			if rerr != nil {
 				fmt.Println(rerr)
 				low := strings.ToLower(rerr.Error())
 				if strings.Contains(low, "already") || strings.Contains(low, "expired") {
@@ -222,7 +274,9 @@ func doShift(client *bl3.Bl3Client, opts shiftOptions) {
 		}
 	}
 
-	if !redeemedAny {
+	if rateLimited {
+		fmt.Println("Stopped early due to repeated SHiFT rate limiting. Progress saved; re-run later to continue.")
+	} else if !redeemedAny {
 		if opts.singleShiftCode != "" {
 			fmt.Println("The single SHIFT code could not be redeemed at this time. Try again later.")
 		} else {
@@ -318,6 +372,7 @@ func main() {
 	}
 	client.Verbose = verbose
 	client.Config.Shift.AllowInactive = allowInactive
+	client.SetThrottle(throttleBase, throttleJitter)
 	fmt.Println(SUCCESS)
 
 	if client.Config.Version != version {

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -16,17 +17,26 @@ import (
 	"github.com/shibukawa/configdir"
 )
 
-// shrinkBackoff sets tiny rate-limit timings (and disables pacing) for the
-// duration of a test so rate-limit paths run fast.
+// shrinkBackoff sets tiny rate-limit timings (and disables pacing, including the
+// rampup throttle/backoff) for the duration of a test so the rate-limit and rampup
+// paths run fast. Rampup thresholds are saved/restored so a test may lower them after
+// calling this and have the originals restored on cleanup.
 func shrinkBackoff(t *testing.T, retries int) {
 	t.Helper()
 	ob, om, or := rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries
 	tb, tj := throttleBase, throttleJitter
+	rtb, rtj, rbb, rbm, rba, rsa := rampupThrottleBase, rampupThrottleJitter,
+		rampupBackoffBase, rampupBackoffMax, rampupBackoffAfter, rampupStopAfter
 	rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = time.Millisecond, time.Millisecond, retries
 	throttleBase, throttleJitter = 0, 0
+	rampupThrottleBase, rampupThrottleJitter = 0, 0
+	rampupBackoffBase, rampupBackoffMax = 0, 0
 	t.Cleanup(func() {
 		rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = ob, om, or
 		throttleBase, throttleJitter = tb, tj
+		rampupThrottleBase, rampupThrottleJitter = rtb, rtj
+		rampupBackoffBase, rampupBackoffMax = rbb, rbm
+		rampupBackoffAfter, rampupStopAfter = rba, rsa
 	})
 }
 
@@ -99,7 +109,7 @@ func TestDoShiftCachesAcrossRuns(t *testing.T) {
 
 	// The cache must now hold all n codes (each on steam+epic).
 	folder := &configdir.Config{Path: cacheDir, Type: configdir.Global}
-	cached := readRedeemedCodes(folder, "cache-test-shift-codes.json")
+	cached, _, _ := readRedeemedCache(folder, "cache-test-shift-codes.json")
 	if len(cached) != n {
 		t.Fatalf("expected %d codes cached, got %d", n, len(cached))
 	}
@@ -121,26 +131,75 @@ func TestRedeemedCodesRoundTrip(t *testing.T) {
 	folder := &configdir.Config{Path: t.TempDir(), Type: configdir.Global}
 	const fn = "test-shift-codes.json"
 
-	// No codes/ dir at all (nil folder) → empty map.
-	if got := readRedeemedCodes(nil, fn); len(got) != 0 {
-		t.Errorf("nil folder should yield empty map, got %v", got)
+	// No codes/ dir at all (nil folder) → empty map, no file.
+	if got, _, existed := readRedeemedCache(nil, fn); len(got) != 0 || existed {
+		t.Errorf("nil folder should yield empty map and existed=false, got %v existed=%v", got, existed)
 	}
-	// codes/ dir exists but has no cache file yet → empty map.
-	if got := readRedeemedCodes(folder, fn); len(got) != 0 {
-		t.Errorf("missing file should yield empty map, got %v", got)
+	// codes/ dir exists but has no cache file yet → empty map, existed=false.
+	if got, _, existed := readRedeemedCache(folder, fn); len(got) != 0 || existed {
+		t.Errorf("missing file should yield empty map and existed=false, got %v existed=%v", got, existed)
 	}
 
-	// Write then read back through the codes/ folder.
+	// Write then read back through the codes/ folder, with a stamped lastRun.
 	want := bl3.ShiftCodeMap{"ABCDE-FGHIJ": {"steam", "epic"}}
-	if err := writeRedeemedCodes(folder, fn, want); err != nil {
+	stamp := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if err := writeRedeemedCache(folder, fn, want, stamp); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	if !folder.Exists(fn) {
 		t.Fatalf("expected %s to exist in the codes folder after write", fn)
 	}
-	got := readRedeemedCodes(folder, fn)
+	got, lastRun, existed := readRedeemedCache(folder, fn)
+	if !existed {
+		t.Error("existed should be true after write")
+	}
 	if !got.Contains("ABCDE-FGHIJ", "steam") || !got.Contains("ABCDE-FGHIJ", "epic") {
 		t.Errorf("round-trip mismatch: %v", got)
+	}
+	if !lastRun.Equal(stamp) {
+		t.Errorf("lastRun round-trip: got %v want %v", lastRun, stamp)
+	}
+}
+
+// TestReadRedeemedCacheBackCompat: an old bare-map file (no wrapper) still reads,
+// with zero lastRun and existed=true.
+func TestReadRedeemedCacheBackCompat(t *testing.T) {
+	folder := &configdir.Config{Path: t.TempDir(), Type: configdir.Global}
+	const fn = "legacy-shift-codes.json"
+	if err := folder.WriteFile(fn, []byte(`{"OLD11-OLD22":["steam","epic"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	got, lastRun, existed := readRedeemedCache(folder, fn)
+	if !existed {
+		t.Error("existed should be true for an old-format file")
+	}
+	if !got.Contains("OLD11-OLD22", "steam") || !got.Contains("OLD11-OLD22", "epic") {
+		t.Errorf("old-format codes not read: %v", got)
+	}
+	if !lastRun.IsZero() {
+		t.Errorf("old-format lastRun should be zero, got %v", lastRun)
+	}
+}
+
+func TestRampupAdvised(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name    string
+		existed bool
+		lastRun time.Time
+		want    bool
+	}{
+		{"no cache file", false, time.Time{}, true},
+		{"old format, zero lastRun", true, time.Time{}, true},
+		{"7 months ago", true, now.AddDate(0, -7, 0), true},
+		{"1 month ago", true, now.AddDate(0, -1, 0), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rampupAdvised(tc.existed, tc.lastRun, now); got != tc.want {
+				t.Errorf("rampupAdvised(%v, %v) = %v, want %v", tc.existed, tc.lastRun, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -209,6 +268,142 @@ func TestDoShiftRateLimitStops(t *testing.T) {
 	})
 	if !strings.Contains(out, "Stopped early") {
 		t.Errorf("expected rate-limit stop message, got:\n%s", out)
+	}
+}
+
+// rampupListJSON builds a v2 code list of n codes named CODE01..CODEnn.
+func rampupListJSON(n int) string {
+	var b strings.Builder
+	b.WriteString(`[{"meta":{},"codes":[`)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"code":"CODE%02d","expired":false}`, i)
+	}
+	b.WriteString(`]}]`)
+	return b.String()
+}
+
+// TestRampupStopsAfterConsecutiveNon200: when the code-query keeps returning 302,
+// rampup backs off and then stops cleanly once it hits rampupStopAfter in a row —
+// without querying every remaining code.
+func TestRampupStopsAfterConsecutiveNon200(t *testing.T) {
+	shrinkBackoff(t, 1)
+	rampupBackoffAfter, rampupStopAfter = 2, 5
+
+	const n = 10
+	listJSON := rampupListJSON(n)
+	queries := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			queries++
+			w.Header().Set("Location", "/home")
+			w.WriteHeader(http.StatusFound) // 302: soft rate-limit
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	usernameHash = "unittest-rampup-stop"
+	useTempCache(t)
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() { doShift(c, shiftOptions{rampup: true}) })
+
+	if queries != rampupStopAfter {
+		t.Errorf("expected exactly %d code queries before stopping, got %d", rampupStopAfter, queries)
+	}
+	if got := strings.Count(out, "Skipping "); got != rampupStopAfter {
+		t.Errorf("expected %d skip lines, got %d:\n%s", rampupStopAfter, got, out)
+	}
+	if !strings.Contains(out, "Stopped after") {
+		t.Errorf("expected shadowban stop message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "backing off") {
+		t.Errorf("expected backoff message after %d in a row, got:\n%s", rampupBackoffAfter, out)
+	}
+}
+
+// TestRampupCounterResetsOn200: an interleaved 200 resets the consecutive counter,
+// so a steady drip of 302s never reaches the stop threshold.
+func TestRampupCounterResetsOn200(t *testing.T) {
+	shrinkBackoff(t, 1)
+	rampupBackoffAfter, rampupStopAfter = 100, 5 // never back off; stop at 5 in a row
+
+	const n = 12
+	listJSON := rampupListJSON(n)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			// Every 3rd code answers 200 (an alert, no form) → resets the counter.
+			num, _ := strconv.Atoi(strings.TrimPrefix(r.URL.Query().Get("code"), "CODE"))
+			if num%3 == 0 {
+				_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has expired</div>`)
+				return
+			}
+			w.Header().Set("Location", "/home")
+			w.WriteHeader(http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	usernameHash = "unittest-rampup-reset"
+	useTempCache(t)
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() { doShift(c, shiftOptions{rampup: true}) })
+
+	if strings.Contains(out, "Stopped after") {
+		t.Errorf("counter should reset on 200 and never stop, got:\n%s", out)
+	}
+	if got := strings.Count(out, "Skipping "); got != 8 { // codes not divisible by 3
+		t.Errorf("expected 8 skips across %d codes, got %d:\n%s", n, got, out)
+	}
+}
+
+// TestDoShiftBumpsLastRunAndUpgrades: a normal run over an old bare-map cache file
+// rewrites it in the versioned format with a fresh lastRun, preserving prior codes.
+func TestDoShiftBumpsLastRunAndUpgrades(t *testing.T) {
+	shrinkBackoff(t, 5)
+	cacheDir := useTempCache(t)
+	usernameHash = "unittest-upgrade"
+	fn := usernameHash + "-shift-codes.json"
+
+	// Seed an old-format (bare map) cache file.
+	folder := &configdir.Config{Path: cacheDir, Type: configdir.Global}
+	if err := folder.WriteFile(fn, []byte(`{"OLDCODE-XYZ":["steam","epic"]}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := cachingTestServer(t, 2)
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+
+	codes, lastRun, existed := readRedeemedCache(folder, fn)
+	if !existed || lastRun.IsZero() {
+		t.Fatalf("expected upgraded cache with a lastRun; existed=%v lastRun=%v", existed, lastRun)
+	}
+	if time.Since(lastRun) > time.Minute {
+		t.Errorf("lastRun should be recent, got %v", lastRun)
+	}
+	if !codes.Contains("OLDCODE-XYZ", "steam") {
+		t.Errorf("prior codes should be preserved across upgrade: %v", codes)
+	}
+	if !codes.Contains("CODE01", "steam") || !codes.Contains("CODE01", "epic") {
+		t.Errorf("newly redeemed codes should be recorded: %v", codes)
 	}
 }
 

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -547,6 +547,94 @@ func TestResolveCacheFolderPrefersLocal(t *testing.T) {
 	}
 }
 
+// countingShiftServer serves the given v2 list and offers steam+epic forms with
+// successful redemptions, counting code-query requests via the returned pointer.
+func countingShiftServer(t *testing.T, listJSON string) (*httptest.Server, *int) {
+	t.Helper()
+	queries := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			queries++
+			code := r.URL.Query().Get("code")
+			for _, svc := range []string{"steam", "epic"} {
+				_, _ = io.WriteString(w, `<form class="new_archway_code_redemption" id="new_archway_code_redemption">`+
+					`<input id="archway_code_redemption_service" name="archway_code_redemption[service]" value="`+svc+`">`+
+					`<input name="archway_code_redemption[code]" value="`+code+`"></form>`)
+			}
+		case "/code_redemptions":
+			_, _ = io.WriteString(w, `<div class="alert">Your code was successfully redeemed</div>`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	return srv, &queries
+}
+
+// TestDoShiftMarksCompleteAndSkipsQuery: once a code is redeemed on every offered
+// platform it is marked complete and skipped (no query) next run; --refresh forces
+// a re-query.
+func TestDoShiftMarksCompleteAndSkipsQuery(t *testing.T) {
+	shrinkBackoff(t, 5)
+	usernameHash = "unittest-complete"
+	useTempCache(t)
+	srv, queries := countingShiftServer(t, `[{"meta":{},"codes":[{"code":"ALLCODE","expired":false}]}]`)
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	// Run 1: query once, redeem steam+epic → marked complete.
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if *queries != 1 {
+		t.Fatalf("run 1 should query once, got %d", *queries)
+	}
+	cached, _, _ := readRedeemedCache(resolveCacheFolder(), usernameHash+"-shift-codes.json")
+	if !cached.Contains("ALLCODE", completeMarker) {
+		t.Fatalf("code redeemed on all platforms should be marked complete: %v", cached)
+	}
+
+	// Run 2 (no --refresh): the complete code is skipped without a query.
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if *queries != 1 {
+		t.Errorf("run 2 should skip the complete code, got %d total queries", *queries)
+	}
+
+	// Run 3 (--refresh): the complete code is re-queried.
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{refresh: true}) })
+	if *queries != 2 {
+		t.Errorf("--refresh should re-query the complete code, got %d total queries", *queries)
+	}
+}
+
+// TestPlatformFilterDoesNotComplete: a --platform run leaves other platforms
+// un-redeemed, so the code is not marked complete and is re-queried next run.
+func TestPlatformFilterDoesNotComplete(t *testing.T) {
+	shrinkBackoff(t, 5)
+	usernameHash = "unittest-filter-complete"
+	useTempCache(t)
+	srv, queries := countingShiftServer(t, `[{"meta":{},"codes":[{"code":"ALLCODE","expired":false}]}]`)
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{platformFilter: []string{"steam"}}) })
+	cached, _, _ := readRedeemedCache(resolveCacheFolder(), usernameHash+"-shift-codes.json")
+	if cached.Contains("ALLCODE", completeMarker) {
+		t.Errorf("a platform-filtered run must not mark a code complete: %v", cached)
+	}
+	if !cached.Contains("ALLCODE", "steam") || cached.Contains("ALLCODE", "epic") {
+		t.Errorf("only steam should be redeemed under the filter: %v", cached)
+	}
+
+	// Next run (no filter) must re-query, since epic is still pending.
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if *queries != 2 {
+		t.Errorf("incomplete code should be re-queried, got %d total queries", *queries)
+	}
+}
+
 func TestSummarize(t *testing.T) {
 	if got := summarize("  hello   world \n"); got != "hello world" {
 		t.Errorf("collapse whitespace: got %q", got)

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -28,6 +28,7 @@ func shrinkBackoff(t *testing.T, retries int) {
 	tb, tj := throttleBase, throttleJitter
 	rtb, rtj, bb, bm, ba, sa := rampupThrottleBase, rampupThrottleJitter,
 		backoffBase, backoffMax, backoffAfter, stopAfter
+	tc, tsf, tsp, tsa := throttleCeil, throttleSlowFactor, throttleSpeedup, throttleSpeedupAfter
 	rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = time.Millisecond, time.Millisecond, retries
 	throttleBase, throttleJitter = 0, 0
 	rampupThrottleBase, rampupThrottleJitter = 0, 0
@@ -38,6 +39,7 @@ func shrinkBackoff(t *testing.T, retries int) {
 		rampupThrottleBase, rampupThrottleJitter = rtb, rtj
 		backoffBase, backoffMax = bb, bm
 		backoffAfter, stopAfter = ba, sa
+		throttleCeil, throttleSlowFactor, throttleSpeedup, throttleSpeedupAfter = tc, tsf, tsp, tsa
 	})
 }
 
@@ -745,6 +747,62 @@ func TestBulkStopsOn302WithoutRampup(t *testing.T) {
 	}
 	if !strings.Contains(out, "Stopped after") {
 		t.Errorf("expected the stop message without --rampup, got:\n%s", out)
+	}
+}
+
+// TestDoShiftSlowsOnRepeated302: the adaptive throttle widens the request spacing
+// on repeated non-200 code queries, up to the ceiling.
+func TestDoShiftSlowsOnRepeated302(t *testing.T) {
+	shrinkBackoff(t, 1)
+	backoffAfter, stopAfter = 100, 100 // keep the emergency brake from firing/stopping
+	throttleBase, throttleJitter = time.Millisecond, 0
+	throttleCeil = 8 * time.Millisecond
+	throttleSlowFactor = 2.0
+	usernameHash = "unittest-aimd-slow"
+	useTempCache(t)
+
+	listJSON := rampupListJSON(10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			w.WriteHeader(http.StatusFound) // 302 throttle (no Location → not an auth redirect)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) }) // 10 codes => bulk
+	if got := c.CurrentInterval(); got <= time.Millisecond {
+		t.Errorf("repeated 302s should widen the throttle above the 1ms floor, got %s", got)
+	}
+	if got := c.CurrentInterval(); got > throttleCeil {
+		t.Errorf("throttle should be capped at ceil %s, got %s", throttleCeil, got)
+	}
+}
+
+// TestDoShiftSpeedsUpOnCleanStreak: an all-clean bulk run never drifts the throttle
+// above the configured floor (and exercises the speed-up path).
+func TestDoShiftSpeedsUpOnCleanStreak(t *testing.T) {
+	shrinkBackoff(t, 1)
+	throttleBase, throttleJitter = 2*time.Millisecond, 0
+	throttleSpeedup = time.Millisecond
+	throttleSpeedupAfter = 3
+	usernameHash = "unittest-aimd-fast"
+	useTempCache(t)
+
+	srv := cachingTestServer(t, 10) // 10 codes, all redeem cleanly
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
+	if got := c.CurrentInterval(); got != 2*time.Millisecond {
+		t.Errorf("a clean run should hold the throttle at the 2ms floor, got %s", got)
 	}
 }
 

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -102,7 +103,7 @@ func TestDoShiftCachesAcrossRuns(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	// Run 1: a fresh cache, so every code (on both services) is redeemed.
-	out1 := captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	out1 := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if got := strings.Count(out1, "Trying "); got != n*2 {
 		t.Errorf("run 1 should attempt %d redemptions, got %d:\n%s", n*2, got, out1)
 	}
@@ -118,12 +119,88 @@ func TestDoShiftCachesAcrossRuns(t *testing.T) {
 	}
 
 	// Run 2: everything is cached, so nothing is attempted.
-	out2 := captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	out2 := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if strings.Contains(out2, "Trying ") {
 		t.Errorf("run 2 should skip all cached codes, but attempted a redemption:\n%s", out2)
 	}
 	if !strings.Contains(out2, "No new SHIFT codes") {
 		t.Errorf("run 2 should report no new codes, got:\n%s", out2)
+	}
+}
+
+func TestSleepCtxInterrupted(t *testing.T) {
+	// A live context: a short sleep completes and returns true.
+	if !sleepCtx(context.Background(), time.Millisecond) {
+		t.Error("sleepCtx with a live context should return true")
+	}
+	// A cancelled context: returns false promptly without waiting out d.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if sleepCtx(ctx, time.Hour) {
+		t.Error("sleepCtx with a cancelled context should return false")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("sleepCtx should abort promptly on cancel, took %s", elapsed)
+	}
+	// Zero/negative duration reflects the live/cancelled context state.
+	if !sleepCtx(context.Background(), 0) {
+		t.Error("sleepCtx(ctx,0) on a live context should return true")
+	}
+	if sleepCtx(ctx, 0) {
+		t.Error("sleepCtx(ctx,0) on a cancelled context should return false")
+	}
+}
+
+// TestDoShiftInterruptSavesProgress: a Ctrl-C (context cancel) mid-run stops
+// cleanly between codes and the cache holds what was redeemed so far.
+func TestDoShiftInterruptSavesProgress(t *testing.T) {
+	shrinkBackoff(t, 5)
+	usernameHash = "unittest-interrupt"
+	useTempCache(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listJSON := rampupListJSON(5)
+	queries := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			queries++
+			code := r.URL.Query().Get("code")
+			for _, svc := range []string{"steam", "epic"} {
+				_, _ = io.WriteString(w, `<form class="new_archway_code_redemption" id="new_archway_code_redemption">`+
+					`<input id="archway_code_redemption_service" name="archway_code_redemption[service]" value="`+svc+`">`+
+					`<input name="archway_code_redemption[code]" value="`+code+`"></form>`)
+			}
+		case "/code_redemptions":
+			_, _ = io.WriteString(w, `<div class="alert">Your code was successfully redeemed</div>`)
+			cancel() // simulate Ctrl-C once the first redemption lands
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() { doShift(ctx, c, shiftOptions{}) })
+	if !strings.Contains(out, "Interrupted") {
+		t.Errorf("expected the interrupted message, got:\n%s", out)
+	}
+	// Only the first code was queried before the interrupt was observed at the
+	// top of the next iteration.
+	if queries != 1 {
+		t.Errorf("expected the run to stop after the first code, got %d queries", queries)
+	}
+	cached, _, _ := readRedeemedCache(resolveCacheFolder(), usernameHash+"-shift-codes.json")
+	if !cached.Contains("CODE01", "steam") {
+		t.Errorf("the first code's progress should be saved, got %v", cached)
+	}
+	if _, ok := cached["CODE02"]; ok {
+		t.Errorf("the second code should not have been processed: %v", cached)
 	}
 }
 
@@ -264,7 +341,7 @@ func TestDoShiftRateLimitStops(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
-		doShift(c, shiftOptions{dryrun: true}) // no single code -> full list -> bulk
+		doShift(context.Background(), c, shiftOptions{dryrun: true}) // no single code -> full list -> bulk
 	})
 	if !strings.Contains(out, "Stopped early") {
 		t.Errorf("expected rate-limit stop message, got:\n%s", out)
@@ -314,7 +391,7 @@ func TestRampupStopsAfterConsecutiveNon200(t *testing.T) {
 	useTempCache(t)
 	c := newDoShiftClient(t, srv.URL)
 
-	out := captureStdout(t, func() { doShift(c, shiftOptions{rampup: true}) })
+	out := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{rampup: true}) })
 
 	if queries != stopAfter {
 		t.Errorf("expected exactly %d code queries before stopping, got %d", stopAfter, queries)
@@ -362,7 +439,7 @@ func TestRampupCounterResetsOn200(t *testing.T) {
 	useTempCache(t)
 	c := newDoShiftClient(t, srv.URL)
 
-	out := captureStdout(t, func() { doShift(c, shiftOptions{rampup: true}) })
+	out := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{rampup: true}) })
 
 	if strings.Contains(out, "Stopped after") {
 		t.Errorf("counter should reset on 200 and never stop, got:\n%s", out)
@@ -390,7 +467,7 @@ func TestDoShiftBumpsLastRunAndUpgrades(t *testing.T) {
 	defer srv.Close()
 	c := newDoShiftClient(t, srv.URL)
 
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 
 	codes, lastRun, existed := readRedeemedCache(folder, fn)
 	if !existed || lastRun.IsZero() {
@@ -466,7 +543,7 @@ func TestDoShiftCountLimit(t *testing.T) {
 	defer srv.Close()
 	c := newDoShiftClient(t, srv.URL)
 
-	out := captureStdout(t, func() { doShift(c, shiftOptions{count: 2}) })
+	out := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{count: 2}) })
 
 	if got := strings.Count(out, "Trying "); got != 2 {
 		t.Errorf("--count 2 should attempt exactly 2 redemptions, got %d:\n%s", got, out)
@@ -502,7 +579,7 @@ func TestDoShiftExpiredCachedAndSkipped(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	// Run 1: the code is queried once, found expired, and cached as such.
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if queries != 1 {
 		t.Fatalf("run 1 should query the code once, got %d", queries)
 	}
@@ -513,7 +590,7 @@ func TestDoShiftExpiredCachedAndSkipped(t *testing.T) {
 	}
 
 	// Run 2: the expired code is skipped outright — no further query.
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if queries != 1 {
 		t.Errorf("run 2 should skip the expired code (no new query), got %d total queries", queries)
 	}
@@ -587,7 +664,7 @@ func TestDoShiftMarksCompleteAndSkipsQuery(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	// Run 1: query once, redeem steam+epic → marked complete.
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if *queries != 1 {
 		t.Fatalf("run 1 should query once, got %d", *queries)
 	}
@@ -597,13 +674,13 @@ func TestDoShiftMarksCompleteAndSkipsQuery(t *testing.T) {
 	}
 
 	// Run 2 (no --refresh): the complete code is skipped without a query.
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if *queries != 1 {
 		t.Errorf("run 2 should skip the complete code, got %d total queries", *queries)
 	}
 
 	// Run 3 (--refresh): the complete code is re-queried.
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{refresh: true}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{refresh: true}) })
 	if *queries != 2 {
 		t.Errorf("--refresh should re-query the complete code, got %d total queries", *queries)
 	}
@@ -619,7 +696,7 @@ func TestPlatformFilterDoesNotComplete(t *testing.T) {
 	defer srv.Close()
 	c := newDoShiftClient(t, srv.URL)
 
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{platformFilter: []string{"steam"}}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{platformFilter: []string{"steam"}}) })
 	cached, _, _ := readRedeemedCache(resolveCacheFolder(), usernameHash+"-shift-codes.json")
 	if cached.Contains("ALLCODE", completeMarker) {
 		t.Errorf("a platform-filtered run must not mark a code complete: %v", cached)
@@ -629,7 +706,7 @@ func TestPlatformFilterDoesNotComplete(t *testing.T) {
 	}
 
 	// Next run (no filter) must re-query, since epic is still pending.
-	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
 	if *queries != 2 {
 		t.Errorf("incomplete code should be re-queried, got %d total queries", *queries)
 	}
@@ -662,7 +739,7 @@ func TestBulkStopsOn302WithoutRampup(t *testing.T) {
 	defer srv.Close()
 	c := newDoShiftClient(t, srv.URL)
 
-	out := captureStdout(t, func() { doShift(c, shiftOptions{}) }) // 20 codes => bulk, no --rampup
+	out := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) }) // 20 codes => bulk, no --rampup
 	if queries != stopAfter {
 		t.Errorf("bulk run should stop after %d consecutive non-200s, got %d queries", stopAfter, queries)
 	}
@@ -685,7 +762,7 @@ func TestGameFilter(t *testing.T) {
 		srv, queries := countingShiftServer(t, listJSON)
 		defer srv.Close()
 		c := newDoShiftClient(t, srv.URL)
-		_ = captureStdout(t, func() { doShift(c, shiftOptions{gameSkip: []string{"borderlands 4"}}) })
+		_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{gameSkip: []string{"borderlands 4"}}) })
 		if *queries != 1 {
 			t.Errorf("skip-game should query only the non-skipped code, got %d", *queries)
 		}
@@ -702,7 +779,7 @@ func TestGameFilter(t *testing.T) {
 		srv, queries := countingShiftServer(t, listJSON)
 		defer srv.Close()
 		c := newDoShiftClient(t, srv.URL)
-		_ = captureStdout(t, func() { doShift(c, shiftOptions{gameInclude: []string{"borderlands 3"}}) })
+		_ = captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{gameInclude: []string{"borderlands 3"}}) })
 		if *queries != 1 {
 			t.Errorf("include-game should query only the matching code, got %d", *queries)
 		}
@@ -825,7 +902,7 @@ func TestDoShiftSingleCodeDryRun(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
-		doShift(c, shiftOptions{singleShiftCode: "GOODCODE", dryrun: true})
+		doShift(context.Background(), c, shiftOptions{singleShiftCode: "GOODCODE", dryrun: true})
 	})
 	if !strings.Contains(out, "[dryrun] would redeem 'steam'") ||
 		!strings.Contains(out, "[dryrun] would redeem 'epic'") {
@@ -841,7 +918,7 @@ func TestDoShiftPlatformFilterDryRun(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
-		doShift(c, shiftOptions{singleShiftCode: "GOODCODE", platformFilter: []string{"steam"}, dryrun: true})
+		doShift(context.Background(), c, shiftOptions{singleShiftCode: "GOODCODE", platformFilter: []string{"steam"}, dryrun: true})
 	})
 	if !strings.Contains(out, "would redeem 'steam'") || strings.Contains(out, "would redeem 'epic'") {
 		t.Errorf("platform filter should keep only steam, got:\n%s", out)
@@ -856,7 +933,7 @@ func TestDoShiftAlreadyRedeemedReason(t *testing.T) {
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
-		doShift(c, shiftOptions{singleShiftCode: "USEDCODE", dryrun: true})
+		doShift(context.Background(), c, shiftOptions{singleShiftCode: "USEDCODE", dryrun: true})
 	})
 	if !strings.Contains(strings.ToLower(out), "already been redeemed") {
 		t.Errorf("expected already-redeemed reason, got:\n%s", out)

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -407,6 +407,56 @@ func TestDoShiftBumpsLastRunAndUpgrades(t *testing.T) {
 	}
 }
 
+// TestMigrateInPlace: --migrate upgrades an old bare-map file to the versioned
+// format in place (preserving codes and the zero lastRun), and is idempotent.
+func TestMigrateInPlace(t *testing.T) {
+	cacheDir := useTempCache(t)
+	usernameHash = "unittest-migrate"
+	fn := usernameHash + "-shift-codes.json"
+	folder := &configdir.Config{Path: cacheDir, Type: configdir.Global}
+
+	if err := folder.WriteFile(fn, []byte(`{"OLD11-OLD22":["steam","epic"],"OLD33-OLD44":["steam"]}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, runMigrate)
+	if !strings.Contains(out, "Migrated 2 codes to cache version 2") {
+		t.Errorf("expected migrate summary, got:\n%s", out)
+	}
+
+	// File is now the versioned format, codes preserved, lastRun still zero.
+	data, err := folder.ReadFile(fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"version": 2`) {
+		t.Errorf("migrated file should carry version 2:\n%s", data)
+	}
+	codes, lastRun, existed := readRedeemedCache(folder, fn)
+	if !existed || !codes.Contains("OLD11-OLD22", "epic") || !codes.Contains("OLD33-OLD44", "steam") {
+		t.Errorf("codes not preserved across migrate: %v", codes)
+	}
+	if !lastRun.IsZero() {
+		t.Errorf("migrate should preserve the unknown (zero) lastRun, got %v", lastRun)
+	}
+
+	// Idempotent: a second migrate is a no-op.
+	out = captureStdout(t, runMigrate)
+	if !strings.Contains(out, "already version 2") {
+		t.Errorf("second migrate should be a no-op, got:\n%s", out)
+	}
+}
+
+// TestMigrateNoCache: --migrate with no cache file reports nothing to do.
+func TestMigrateNoCache(t *testing.T) {
+	useTempCache(t)
+	usernameHash = "unittest-migrate-empty"
+	out := captureStdout(t, runMigrate)
+	if !strings.Contains(out, "No redeemed-codes cache to migrate") {
+		t.Errorf("expected no-cache message, got:\n%s", out)
+	}
+}
+
 func TestSummarize(t *testing.T) {
 	if got := summarize("  hello   world \n"); got != "hello world" {
 		t.Errorf("collapse whitespace: got %q", got)

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -30,6 +30,93 @@ func shrinkBackoff(t *testing.T, retries int) {
 	})
 }
 
+// useTempCache points the redeemed-codes cache at a fresh temp dir (standing in
+// for the Docker codes/ volume) for the duration of a test, and returns it.
+func useTempCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := resolveCacheFolder
+	resolveCacheFolder = func() *configdir.Config {
+		return &configdir.Config{Path: dir, Type: configdir.Global}
+	}
+	t.Cleanup(func() { resolveCacheFolder = orig })
+	return dir
+}
+
+// cachingTestServer serves n redeemable codes (each on steam+epic) with
+// successful redemptions, plus the endpoints doShift needs.
+func cachingTestServer(t *testing.T, n int) *httptest.Server {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(`[{"meta":{},"codes":[`)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"code":"CODE%02d","game":"Borderlands 4","expired":false}`, i)
+	}
+	b.WriteString(`]}]`)
+	listJSON := b.String()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			code := r.URL.Query().Get("code")
+			for _, svc := range []string{"steam", "epic"} {
+				_, _ = io.WriteString(w, `<form class="new_archway_code_redemption" id="new_archway_code_redemption">`+
+					`<input id="archway_code_redemption_service" name="archway_code_redemption[service]" value="`+svc+`">`+
+					`<input name="archway_code_redemption[code]" value="`+code+`"></form>`)
+			}
+		case "/code_redemptions":
+			_, _ = io.WriteString(w, `<div class="alert">Your code was successfully redeemed</div>`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+// TestDoShiftCachesAcrossRuns mirrors the manual two-run validation: run 1
+// redeems all codes and writes the cache; run 2 reads the cache and skips them.
+func TestDoShiftCachesAcrossRuns(t *testing.T) {
+	shrinkBackoff(t, 5) // disable pacing so the bulk run is fast
+	cacheDir := useTempCache(t)
+	usernameHash = "cache-test"
+
+	const n = 10
+	srv := cachingTestServer(t, n)
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	// Run 1: a fresh cache, so every code (on both services) is redeemed.
+	out1 := captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if got := strings.Count(out1, "Trying "); got != n*2 {
+		t.Errorf("run 1 should attempt %d redemptions, got %d:\n%s", n*2, got, out1)
+	}
+
+	// The cache must now hold all n codes (each on steam+epic).
+	folder := &configdir.Config{Path: cacheDir, Type: configdir.Global}
+	cached := readRedeemedCodes(folder, "cache-test-shift-codes.json")
+	if len(cached) != n {
+		t.Fatalf("expected %d codes cached, got %d", n, len(cached))
+	}
+	if !cached.Contains("CODE01", "steam") || !cached.Contains("CODE01", "epic") {
+		t.Errorf("cache missing expected services: %v", cached["CODE01"])
+	}
+
+	// Run 2: everything is cached, so nothing is attempted.
+	out2 := captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if strings.Contains(out2, "Trying ") {
+		t.Errorf("run 2 should skip all cached codes, but attempted a redemption:\n%s", out2)
+	}
+	if !strings.Contains(out2, "No new SHIFT codes") {
+		t.Errorf("run 2 should report no new codes, got:\n%s", out2)
+	}
+}
+
 func TestRedeemedCodesRoundTrip(t *testing.T) {
 	folder := &configdir.Config{Path: t.TempDir(), Type: configdir.Global}
 	const fn = "test-shift-codes.json"
@@ -114,6 +201,7 @@ func TestDoShiftRateLimitStops(t *testing.T) {
 	}))
 	defer srv.Close()
 	usernameHash = "unittest-doshift"
+	useTempCache(t)
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
@@ -201,6 +289,7 @@ func TestDoShiftSingleCodeDryRun(t *testing.T) {
 	srv := shiftTestServer()
 	defer srv.Close()
 	usernameHash = "unittest-doshift"
+	useTempCache(t)
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
@@ -216,6 +305,7 @@ func TestDoShiftPlatformFilterDryRun(t *testing.T) {
 	srv := shiftTestServer()
 	defer srv.Close()
 	usernameHash = "unittest-doshift"
+	useTempCache(t)
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
@@ -230,6 +320,7 @@ func TestDoShiftAlreadyRedeemedReason(t *testing.T) {
 	srv := shiftTestServer()
 	defer srv.Close()
 	usernameHash = "unittest-doshift"
+	useTempCache(t)
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bl3 "github.com/jauderho/bl3auto"
+)
+
+func TestSummarize(t *testing.T) {
+	if got := summarize("  hello   world \n"); got != "hello world" {
+		t.Errorf("collapse whitespace: got %q", got)
+	}
+	if got := summarize("   "); got != "not redeemable" {
+		t.Errorf("empty: got %q", got)
+	}
+	long := strings.Repeat("a", 200)
+	got := summarize(long)
+	if len(got) != 163 || !strings.HasSuffix(got, "...") {
+		t.Errorf("truncate: len=%d suffix ok=%v", len(got), strings.HasSuffix(got, "..."))
+	}
+}
+
+// captureStdout runs fn and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// shiftTestServer emulates the SHiFT endpoints needed by doShift.
+func shiftTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<html><head><meta name="csrf-token" content="tok"></head></html>`)
+		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "GOODCODE":
+			for _, svc := range []string{"steam", "epic"} {
+				_, _ = io.WriteString(w, `<form class="new_archway_code_redemption" id="new_archway_code_redemption">`+
+					`<input id="archway_code_redemption_service" name="archway_code_redemption[service]" value="`+svc+`">`+
+					`<input name="archway_code_redemption[code]" value="GOODCODE"></form>`)
+			}
+		case r.URL.Path == "/entitlement_offer_codes" && r.URL.Query().Get("code") == "USEDCODE":
+			_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has already been redeemed</div>`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+func newDoShiftClient(t *testing.T, baseURL string) *bl3.Bl3Client {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	cfg := `{"baseUrl":"` + baseURL + `","shiftConfig":{` +
+		`"redemptionInfoUrl":"` + baseURL + `/entitlement_offer_codes",` +
+		`"redemptionUrl":"` + baseURL + `/code_redemptions"}}`
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := bl3.NewBl3Client(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestDoShiftSingleCodeDryRun(t *testing.T) {
+	srv := shiftTestServer()
+	defer srv.Close()
+	usernameHash = "unittest-doshift"
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() {
+		doShift(c, shiftOptions{singleShiftCode: "GOODCODE", dryrun: true})
+	})
+	if !strings.Contains(out, "[dryrun] would redeem 'steam'") ||
+		!strings.Contains(out, "[dryrun] would redeem 'epic'") {
+		t.Errorf("expected dryrun output for both services, got:\n%s", out)
+	}
+}
+
+func TestDoShiftPlatformFilterDryRun(t *testing.T) {
+	srv := shiftTestServer()
+	defer srv.Close()
+	usernameHash = "unittest-doshift"
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() {
+		doShift(c, shiftOptions{singleShiftCode: "GOODCODE", platformFilter: []string{"steam"}, dryrun: true})
+	})
+	if !strings.Contains(out, "would redeem 'steam'") || strings.Contains(out, "would redeem 'epic'") {
+		t.Errorf("platform filter should keep only steam, got:\n%s", out)
+	}
+}
+
+func TestDoShiftAlreadyRedeemedReason(t *testing.T) {
+	srv := shiftTestServer()
+	defer srv.Close()
+	usernameHash = "unittest-doshift"
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() {
+		doShift(c, shiftOptions{singleShiftCode: "USEDCODE", dryrun: true})
+	})
+	if !strings.Contains(strings.ToLower(out), "already been redeemed") {
+		t.Errorf("expected already-redeemed reason, got:\n%s", out)
+	}
+}

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -806,6 +806,86 @@ func TestDoShiftSpeedsUpOnCleanStreak(t *testing.T) {
 	}
 }
 
+func TestIsAuthRedirect(t *testing.T) {
+	cases := map[string]bool{
+		"":                         false,
+		"/home":                    false, // SHiFT's throttle target, NOT a sign-in bounce
+		"/entitlement_offer_codes": false,
+		"/login":                   true,
+		"/sessions/new":            true,
+		"/home?redirect_to=false":  true,
+	}
+	for loc, want := range cases {
+		if got := isAuthRedirect(loc); got != want {
+			t.Errorf("isAuthRedirect(%q) = %v, want %v", loc, got, want)
+		}
+	}
+}
+
+// TestWithBackoffHonoursRetryAfter: a server-specified Retry-After wins over the
+// exponential backoff, so withBackoff waits the short server time, not the long
+// exponential one.
+func TestWithBackoffHonoursRetryAfter(t *testing.T) {
+	ob, om, or := rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries
+	rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = time.Hour, time.Hour, 3
+	t.Cleanup(func() { rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = ob, om, or })
+
+	calls := 0
+	start := time.Now()
+	err, stop := withBackoff(true, func() error {
+		calls++
+		if calls == 1 {
+			return &bl3.RateLimitError{Status: 429, RetryAfter: 15 * time.Millisecond}
+		}
+		return nil
+	})
+	if err != nil || stop {
+		t.Fatalf("expected success after honoring Retry-After, got err=%v stop=%v", err, stop)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("should have slept ~15ms (Retry-After), not the 1h exponential; took %s", elapsed)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 op calls, got %d", calls)
+	}
+}
+
+// TestDoShiftStopsOnSessionExpiry: a query 302 that redirects to sign in is treated
+// as a lost session (not a throttle) — the run stops immediately with a clear message
+// rather than counting toward the shadowban brake.
+func TestDoShiftStopsOnSessionExpiry(t *testing.T) {
+	shrinkBackoff(t, 1)
+	usernameHash = "unittest-session"
+	useTempCache(t)
+
+	listJSON := rampupListJSON(10)
+	queries := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			queries++
+			w.Header().Set("Location", "/sessions/new") // bounced to sign in
+			w.WriteHeader(http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() { doShift(context.Background(), c, shiftOptions{}) })
+	if queries != 1 {
+		t.Errorf("session-expiry should stop on the first redirect, got %d queries", queries)
+	}
+	if !strings.Contains(out, "session expired") {
+		t.Errorf("expected the session-expiry message, got:\n%s", out)
+	}
+}
+
 // TestGameFilter: --skip-game / --game filter the candidate list before querying, so
 // codes for excluded games are never queried.
 func TestGameFilter(t *testing.T) {

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -457,6 +457,96 @@ func TestMigrateNoCache(t *testing.T) {
 	}
 }
 
+// TestDoShiftCountLimit: --count stops the run after N successful redemptions.
+func TestDoShiftCountLimit(t *testing.T) {
+	shrinkBackoff(t, 5)
+	usernameHash = "unittest-count"
+	useTempCache(t)
+	srv := cachingTestServer(t, 5) // 5 codes x steam+epic = up to 10 successes
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() { doShift(c, shiftOptions{count: 2}) })
+
+	if got := strings.Count(out, "Trying "); got != 2 {
+		t.Errorf("--count 2 should attempt exactly 2 redemptions, got %d:\n%s", got, out)
+	}
+	if !strings.Contains(out, "Reached the --count limit of 2") {
+		t.Errorf("expected --count limit message, got:\n%s", out)
+	}
+}
+
+// TestDoShiftExpiredCachedAndSkipped: an expired code is recorded in the cache and
+// not re-queried on the next run.
+func TestDoShiftExpiredCachedAndSkipped(t *testing.T) {
+	shrinkBackoff(t, 5)
+	usernameHash = "unittest-expired"
+	useTempCache(t)
+
+	queries := 0
+	listJSON := `[{"meta":{},"codes":[{"code":"EXPCODE","expired":false}]}]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			queries++
+			_, _ = io.WriteString(w, `<div class="alert">This SHiFT code has expired</div>`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	// Run 1: the code is queried once, found expired, and cached as such.
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if queries != 1 {
+		t.Fatalf("run 1 should query the code once, got %d", queries)
+	}
+	folder := resolveCacheFolder()
+	cached, _, _ := readRedeemedCache(folder, usernameHash+"-shift-codes.json")
+	if !cached.Contains("EXPCODE", expiredMarker) {
+		t.Fatalf("expired code should be cached with the expired marker: %v", cached)
+	}
+
+	// Run 2: the expired code is skipped outright — no further query.
+	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
+	if queries != 1 {
+		t.Errorf("run 2 should skip the expired code (no new query), got %d total queries", queries)
+	}
+}
+
+// TestResolveCacheFolderPrefersLocal: the real resolveCacheFolder uses a local
+// codes/ dir when present, and falls back to the config dir otherwise.
+func TestResolveCacheFolderPrefersLocal(t *testing.T) {
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// No codes/ dir → config-dir fallback (not the local path).
+	if f := resolveCacheFolder(); f.Type == configdir.Local && f.Path == "codes" {
+		t.Errorf("without a codes/ dir, should not use the local path; got %+v", f)
+	}
+
+	// With a codes/ dir → local path.
+	if err := os.Mkdir("codes", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if f := resolveCacheFolder(); f.Path != "codes" || f.Type != configdir.Local {
+		t.Errorf("with a codes/ dir, expected local codes path, got %+v", f)
+	}
+}
+
 func TestSummarize(t *testing.T) {
 	if got := summarize("  hello   world \n"); got != "hello world" {
 		t.Errorf("collapse whitespace: got %q", got)

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -13,22 +13,56 @@ import (
 	"time"
 
 	bl3 "github.com/jauderho/bl3auto"
+	"github.com/shibukawa/configdir"
 )
 
-// shrinkBackoff sets tiny rate-limit timings for the duration of a test.
+// shrinkBackoff sets tiny rate-limit timings (and disables pacing) for the
+// duration of a test so rate-limit paths run fast.
 func shrinkBackoff(t *testing.T, retries int) {
 	t.Helper()
 	ob, om, or := rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries
+	tb, tj := throttleBase, throttleJitter
 	rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = time.Millisecond, time.Millisecond, retries
-	t.Cleanup(func() { rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = ob, om, or })
+	throttleBase, throttleJitter = 0, 0
+	t.Cleanup(func() {
+		rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = ob, om, or
+		throttleBase, throttleJitter = tb, tj
+	})
+}
+
+func TestRedeemedCodesRoundTrip(t *testing.T) {
+	folder := &configdir.Config{Path: t.TempDir(), Type: configdir.Global}
+	const fn = "test-shift-codes.json"
+
+	// No codes/ dir at all (nil folder) → empty map.
+	if got := readRedeemedCodes(nil, fn); len(got) != 0 {
+		t.Errorf("nil folder should yield empty map, got %v", got)
+	}
+	// codes/ dir exists but has no cache file yet → empty map.
+	if got := readRedeemedCodes(folder, fn); len(got) != 0 {
+		t.Errorf("missing file should yield empty map, got %v", got)
+	}
+
+	// Write then read back through the codes/ folder.
+	want := bl3.ShiftCodeMap{"ABCDE-FGHIJ": {"steam", "epic"}}
+	if err := writeRedeemedCodes(folder, fn, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !folder.Exists(fn) {
+		t.Fatalf("expected %s to exist in the codes folder after write", fn)
+	}
+	got := readRedeemedCodes(folder, fn)
+	if !got.Contains("ABCDE-FGHIJ", "steam") || !got.Contains("ABCDE-FGHIJ", "epic") {
+		t.Errorf("round-trip mismatch: %v", got)
+	}
 }
 
 func TestWithBackoff(t *testing.T) {
 	shrinkBackoff(t, 3)
 
-	// Rate-limited a few times, then succeeds.
+	// Bulk: rate-limited a few times, then succeeds.
 	calls := 0
-	err, stop := withBackoff(func() error {
+	err, stop := withBackoff(true, func() error {
 		calls++
 		if calls < 3 {
 			return fmt.Errorf("%w", bl3.ErrRateLimited)
@@ -39,15 +73,22 @@ func TestWithBackoff(t *testing.T) {
 		t.Errorf("retry-then-success: err=%v stop=%v calls=%d", err, stop, calls)
 	}
 
-	// Persistent rate limiting → stop.
-	if _, stop := withBackoff(func() error { return fmt.Errorf("%w", bl3.ErrRateLimited) }); !stop {
+	// Bulk: persistent rate limiting → stop.
+	if _, stop := withBackoff(true, func() error { return fmt.Errorf("%w", bl3.ErrRateLimited) }); !stop {
 		t.Error("persistent rate limit should signal stop")
+	}
+
+	// Non-bulk: a rate-limit error is returned immediately, no retry, no stop.
+	calls = 0
+	err, stop = withBackoff(false, func() error { calls++; return fmt.Errorf("%w", bl3.ErrRateLimited) })
+	if stop || !errors.Is(err, bl3.ErrRateLimited) || calls != 1 {
+		t.Errorf("non-bulk: stop=%v err=%v calls=%d", stop, err, calls)
 	}
 
 	// A non-rate-limit error returns immediately without retrying.
 	calls = 0
 	sentinel := errors.New("boom")
-	err, stop = withBackoff(func() error { calls++; return sentinel })
+	err, stop = withBackoff(true, func() error { calls++; return sentinel })
 	if stop || !errors.Is(err, sentinel) || calls != 1 {
 		t.Errorf("passthrough: stop=%v err=%v calls=%d", stop, err, calls)
 	}
@@ -55,19 +96,28 @@ func TestWithBackoff(t *testing.T) {
 
 func TestDoShiftRateLimitStops(t *testing.T) {
 	shrinkBackoff(t, 1)
+	// A full-list (bulk) run: 6 codes triggers the bulk threshold so backoff
+	// applies; the entitlement endpoint always rate-limits.
+	bulkList := `[{"meta":{},"codes":[` +
+		`{"code":"C1","expired":false},{"code":"C2","expired":false},` +
+		`{"code":"C3","expired":false},{"code":"C4","expired":false},` +
+		`{"code":"C5","expired":false},{"code":"C6","expired":false}]}]`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/code_redemptions/new" {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, bulkList)
+		case "/code_redemptions/new":
 			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
-			return
+		default:
+			w.WriteHeader(http.StatusTooManyRequests)
 		}
-		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer srv.Close()
 	usernameHash = "unittest-doshift"
 	c := newDoShiftClient(t, srv.URL)
 
 	out := captureStdout(t, func() {
-		doShift(c, shiftOptions{singleShiftCode: "X", dryrun: true})
+		doShift(c, shiftOptions{dryrun: true}) // no single code -> full list -> bulk
 	})
 	if !strings.Contains(out, "Stopped early") {
 		t.Errorf("expected rate-limit stop message, got:\n%s", out)
@@ -133,6 +183,8 @@ func newDoShiftClient(t *testing.T, baseURL string) *bl3.Bl3Client {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 	cfg := `{"baseUrl":"` + baseURL + `","shiftConfig":{` +
+		`"codeListUrlV2":"` + baseURL + `/v2.json",` +
+		`"codeListUrlV1":"` + baseURL + `/v1.json",` +
 		`"redemptionInfoUrl":"` + baseURL + `/entitlement_offer_codes",` +
 		`"redemptionUrl":"` + baseURL + `/code_redemptions"}}`
 	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -17,26 +17,26 @@ import (
 	"github.com/shibukawa/configdir"
 )
 
-// shrinkBackoff sets tiny rate-limit timings (and disables pacing, including the
-// rampup throttle/backoff) for the duration of a test so the rate-limit and rampup
-// paths run fast. Rampup thresholds are saved/restored so a test may lower them after
+// shrinkBackoff sets tiny rate-limit timings and disables all request pacing/backoff
+// sleeps for the duration of a test so the rate-limit and bulk-backoff paths run fast.
+// The consecutive-non-200 thresholds are saved/restored so a test may lower them after
 // calling this and have the originals restored on cleanup.
 func shrinkBackoff(t *testing.T, retries int) {
 	t.Helper()
 	ob, om, or := rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries
 	tb, tj := throttleBase, throttleJitter
-	rtb, rtj, rbb, rbm, rba, rsa := rampupThrottleBase, rampupThrottleJitter,
-		rampupBackoffBase, rampupBackoffMax, rampupBackoffAfter, rampupStopAfter
+	rtb, rtj, bb, bm, ba, sa := rampupThrottleBase, rampupThrottleJitter,
+		backoffBase, backoffMax, backoffAfter, stopAfter
 	rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = time.Millisecond, time.Millisecond, retries
 	throttleBase, throttleJitter = 0, 0
 	rampupThrottleBase, rampupThrottleJitter = 0, 0
-	rampupBackoffBase, rampupBackoffMax = 0, 0
+	backoffBase, backoffMax = 0, 0
 	t.Cleanup(func() {
 		rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = ob, om, or
 		throttleBase, throttleJitter = tb, tj
 		rampupThrottleBase, rampupThrottleJitter = rtb, rtj
-		rampupBackoffBase, rampupBackoffMax = rbb, rbm
-		rampupBackoffAfter, rampupStopAfter = rba, rsa
+		backoffBase, backoffMax = bb, bm
+		backoffAfter, stopAfter = ba, sa
 	})
 }
 
@@ -286,11 +286,11 @@ func rampupListJSON(n int) string {
 }
 
 // TestRampupStopsAfterConsecutiveNon200: when the code-query keeps returning 302,
-// rampup backs off and then stops cleanly once it hits rampupStopAfter in a row —
+// rampup backs off and then stops cleanly once it hits stopAfter in a row —
 // without querying every remaining code.
 func TestRampupStopsAfterConsecutiveNon200(t *testing.T) {
 	shrinkBackoff(t, 1)
-	rampupBackoffAfter, rampupStopAfter = 2, 5
+	backoffAfter, stopAfter = 2, 5
 
 	const n = 10
 	listJSON := rampupListJSON(n)
@@ -316,17 +316,17 @@ func TestRampupStopsAfterConsecutiveNon200(t *testing.T) {
 
 	out := captureStdout(t, func() { doShift(c, shiftOptions{rampup: true}) })
 
-	if queries != rampupStopAfter {
-		t.Errorf("expected exactly %d code queries before stopping, got %d", rampupStopAfter, queries)
+	if queries != stopAfter {
+		t.Errorf("expected exactly %d code queries before stopping, got %d", stopAfter, queries)
 	}
-	if got := strings.Count(out, "Skipping "); got != rampupStopAfter {
-		t.Errorf("expected %d skip lines, got %d:\n%s", rampupStopAfter, got, out)
+	if got := strings.Count(out, "Skipping "); got != stopAfter {
+		t.Errorf("expected %d skip lines, got %d:\n%s", stopAfter, got, out)
 	}
 	if !strings.Contains(out, "Stopped after") {
 		t.Errorf("expected shadowban stop message, got:\n%s", out)
 	}
 	if !strings.Contains(out, "backing off") {
-		t.Errorf("expected backoff message after %d in a row, got:\n%s", rampupBackoffAfter, out)
+		t.Errorf("expected backoff message after %d in a row, got:\n%s", backoffAfter, out)
 	}
 }
 
@@ -334,7 +334,7 @@ func TestRampupStopsAfterConsecutiveNon200(t *testing.T) {
 // so a steady drip of 302s never reaches the stop threshold.
 func TestRampupCounterResetsOn200(t *testing.T) {
 	shrinkBackoff(t, 1)
-	rampupBackoffAfter, rampupStopAfter = 100, 5 // never back off; stop at 5 in a row
+	backoffAfter, stopAfter = 100, 5 // never back off; stop at 5 in a row
 
 	const n = 12
 	listJSON := rampupListJSON(n)
@@ -632,6 +632,115 @@ func TestPlatformFilterDoesNotComplete(t *testing.T) {
 	_ = captureStdout(t, func() { doShift(c, shiftOptions{}) })
 	if *queries != 2 {
 		t.Errorf("incomplete code should be re-queried, got %d total queries", *queries)
+	}
+}
+
+// TestBulkStopsOn302WithoutRampup: the dialed-back default — even without --rampup,
+// a bulk run stops after stopAfter consecutive non-200 responses.
+func TestBulkStopsOn302WithoutRampup(t *testing.T) {
+	shrinkBackoff(t, 1)
+	backoffAfter, stopAfter = 3, 6
+	usernameHash = "unittest-bulkstop"
+	useTempCache(t)
+
+	listJSON := rampupListJSON(20)
+	queries := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2.json":
+			_, _ = io.WriteString(w, listJSON)
+		case "/code_redemptions/new":
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+		case "/entitlement_offer_codes":
+			queries++
+			w.Header().Set("Location", "/home")
+			w.WriteHeader(http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() { doShift(c, shiftOptions{}) }) // 20 codes => bulk, no --rampup
+	if queries != stopAfter {
+		t.Errorf("bulk run should stop after %d consecutive non-200s, got %d queries", stopAfter, queries)
+	}
+	if !strings.Contains(out, "Stopped after") {
+		t.Errorf("expected the stop message without --rampup, got:\n%s", out)
+	}
+}
+
+// TestGameFilter: --skip-game / --game filter the candidate list before querying, so
+// codes for excluded games are never queried.
+func TestGameFilter(t *testing.T) {
+	listJSON := `[{"meta":{},"codes":[` +
+		`{"code":"BL3CODE","game":"Borderlands 3","expired":false},` +
+		`{"code":"BL4CODE","game":"Borderlands 4","expired":false}]}]`
+
+	t.Run("skip", func(t *testing.T) {
+		shrinkBackoff(t, 5)
+		usernameHash = "unittest-skipgame"
+		useTempCache(t)
+		srv, queries := countingShiftServer(t, listJSON)
+		defer srv.Close()
+		c := newDoShiftClient(t, srv.URL)
+		_ = captureStdout(t, func() { doShift(c, shiftOptions{gameSkip: []string{"borderlands 4"}}) })
+		if *queries != 1 {
+			t.Errorf("skip-game should query only the non-skipped code, got %d", *queries)
+		}
+		cached, _, _ := readRedeemedCache(resolveCacheFolder(), usernameHash+"-shift-codes.json")
+		if cached.Contains("BL4CODE", "steam") {
+			t.Errorf("a skipped game's code must not be redeemed: %v", cached)
+		}
+	})
+
+	t.Run("include", func(t *testing.T) {
+		shrinkBackoff(t, 5)
+		usernameHash = "unittest-incgame"
+		useTempCache(t)
+		srv, queries := countingShiftServer(t, listJSON)
+		defer srv.Close()
+		c := newDoShiftClient(t, srv.URL)
+		_ = captureStdout(t, func() { doShift(c, shiftOptions{gameInclude: []string{"borderlands 3"}}) })
+		if *queries != 1 {
+			t.Errorf("include-game should query only the matching code, got %d", *queries)
+		}
+	})
+}
+
+func TestMatchesGame(t *testing.T) {
+	cases := []struct {
+		name          string
+		include, skip []string
+		game          string
+		want          bool
+	}{
+		{"no filters", nil, nil, "Borderlands 4", true},
+		{"skip matches", nil, []string{"borderlands 4"}, "Borderlands 4", false},
+		{"skip misses", nil, []string{"borderlands 4"}, "Borderlands 3", true},
+		{"include matches", []string{"wonderlands"}, nil, "Tiny Tina's Wonderlands", true},
+		{"include misses", []string{"borderlands 3"}, nil, "Borderlands 4", false},
+		{"skip wins over include", []string{"borderlands"}, []string{"borderlands 4"}, "Borderlands 4", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchesGame(tc.include, tc.skip, tc.game); got != tc.want {
+				t.Errorf("matchesGame(%v,%v,%q)=%v want %v", tc.include, tc.skip, tc.game, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccountPlatforms(t *testing.T) {
+	m := bl3.ShiftCodeMap{
+		"A": {"epic", "steam"},
+		"B": {"steam", completeMarker},
+		"C": {expiredMarker},
+	}
+	got := accountPlatforms(m)
+	if len(got) != 2 || got[0] != "epic" || got[1] != "steam" {
+		t.Errorf("accountPlatforms should return sorted real services {epic,steam}, got %v", got)
 	}
 }
 

--- a/cmd/bl3auto_test.go
+++ b/cmd/bl3auto_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -8,9 +10,69 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	bl3 "github.com/jauderho/bl3auto"
 )
+
+// shrinkBackoff sets tiny rate-limit timings for the duration of a test.
+func shrinkBackoff(t *testing.T, retries int) {
+	t.Helper()
+	ob, om, or := rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries
+	rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = time.Millisecond, time.Millisecond, retries
+	t.Cleanup(func() { rateLimitBaseWait, rateLimitMaxWait, rateLimitRetries = ob, om, or })
+}
+
+func TestWithBackoff(t *testing.T) {
+	shrinkBackoff(t, 3)
+
+	// Rate-limited a few times, then succeeds.
+	calls := 0
+	err, stop := withBackoff(func() error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("%w", bl3.ErrRateLimited)
+		}
+		return nil
+	})
+	if err != nil || stop || calls != 3 {
+		t.Errorf("retry-then-success: err=%v stop=%v calls=%d", err, stop, calls)
+	}
+
+	// Persistent rate limiting → stop.
+	if _, stop := withBackoff(func() error { return fmt.Errorf("%w", bl3.ErrRateLimited) }); !stop {
+		t.Error("persistent rate limit should signal stop")
+	}
+
+	// A non-rate-limit error returns immediately without retrying.
+	calls = 0
+	sentinel := errors.New("boom")
+	err, stop = withBackoff(func() error { calls++; return sentinel })
+	if stop || !errors.Is(err, sentinel) || calls != 1 {
+		t.Errorf("passthrough: stop=%v err=%v calls=%d", stop, err, calls)
+	}
+}
+
+func TestDoShiftRateLimitStops(t *testing.T) {
+	shrinkBackoff(t, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/code_redemptions/new" {
+			_, _ = io.WriteString(w, `<meta name="csrf-token" content="t">`)
+			return
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	usernameHash = "unittest-doshift"
+	c := newDoShiftClient(t, srv.URL)
+
+	out := captureStdout(t, func() {
+		doShift(c, shiftOptions{singleShiftCode: "X", dryrun: true})
+	})
+	if !strings.Contains(out, "Stopped early") {
+		t.Errorf("expected rate-limit stop message, got:\n%s", out)
+	}
+}
 
 func TestSummarize(t *testing.T) {
 	if got := summarize("  hello   world \n"); got != "hello world" {

--- a/config.json
+++ b/config.json
@@ -1,17 +1,16 @@
 {
     "version": "2.2.28",
-    "loginUrl": "https://api.2k.com/borderlands/users/authenticate",
-    "loginRedirectHeader": "X-CT-REDIRECT",
-    "sessionIdHeader": "X-SESSION-SET",
-    "sessionHeader": "X-SESSION",
+    "baseUrl": "https://shift.gearboxsoftware.com",
+    "homeUrl": "https://shift.gearboxsoftware.com/home",
+    "loginUrl": "https://shift.gearboxsoftware.com/sessions",
     "requestHeaders": {
-        "Origin": "https://borderlands.com",
-        "Referer": "https://borderlands.com/en-US/"
+        "Origin": "https://shift.gearboxsoftware.com",
+        "Referer": "https://shift.gearboxsoftware.com/home"
     },
     "shiftConfig": {
-        "codeListUrl": "https://raw.githubusercontent.com/ugoogalizer/autoshift-codes/main/shiftcodes.json",
-        "codeInfoUrl": "https://api.2k.com/borderlands/code/",
-        "userInfoUrl": "https://api.2k.com/borderlands/users/me",
-        "gameCodename": "oak"
+        "codeListUrlV2": "https://raw.githubusercontent.com/ugoogalizer/autoshift-codes/refs/heads/main/shiftcodes.json",
+        "codeListUrlV1": "https://raw.githubusercontent.com/jauderho/shift-codes/refs/heads/main/orcicorn/shift-code/index.json",
+        "redemptionInfoUrl": "https://shift.gearboxsoftware.com/entitlement_offer_codes",
+        "redemptionUrl": "https://shift.gearboxsoftware.com/code_redemptions"
     }
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.2.28",
+    "version": "2.3.0",
     "baseUrl": "https://shift.gearboxsoftware.com",
     "homeUrl": "https://shift.gearboxsoftware.com/home",
     "loginUrl": "https://shift.gearboxsoftware.com/sessions",

--- a/shift.go
+++ b/shift.go
@@ -24,11 +24,9 @@ type ShiftConfig struct {
 
 // ShiftCode is a single code parsed from either code-list format.
 type ShiftCode struct {
-	Code     string `json:"code"`
-	Game     string `json:"game"`
-	Platform string `json:"platform"`
-	Reward   string `json:"reward"`
-	Expired  bool   `json:"expired"`
+	Code    string `json:"code"`
+	Game    string `json:"game"`
+	Expired bool   `json:"expired"`
 }
 
 // ShiftCodeMap tracks which services a code has been redeemed on (the on-disk cache).
@@ -55,7 +53,7 @@ type RedemptionForm struct {
 func parseCodeList(body []byte, dropExpired bool) []ShiftCode {
 	parsed := make([]ShiftCode, 0)
 	JsonFromBytes(body).From("[0].codes").
-		Select("code", "game", "platform", "reward", "expired").Out(&parsed)
+		Select("code", "game", "expired").Out(&parsed)
 
 	codes := make([]ShiftCode, 0, len(parsed))
 	for _, c := range parsed {

--- a/shift.go
+++ b/shift.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -176,13 +175,18 @@ func (client *Bl3Client) GetCodeRedemptionForms(code string) ([]RedemptionForm, 
 	client.logf("GET %s?code=%s -> %d", client.Config.Shift.RedemptionInfoUrl, code, res.StatusCode)
 
 	if res.StatusCode == http.StatusTooManyRequests || res.StatusCode == http.StatusServiceUnavailable {
-		return nil, "", fmt.Errorf("%w (status %d)", ErrRateLimited, res.StatusCode)
+		return nil, "", &RateLimitError{Status: res.StatusCode, RetryAfter: parseRetryAfter(res.Header)}
 	}
 	if res.StatusCode != 200 {
 		// A non-200 here is either an invalid code (e.g. 5xx) or, commonly, a 302
-		// redirect when SHiFT is soft rate-limiting / shadowbanning us. The typed
-		// error lets the caller count consecutive failures (see --rampup).
-		return nil, "", &CodeQueryStatusError{Status: res.StatusCode}
+		// redirect when SHiFT is soft rate-limiting / shadowbanning us (or bouncing
+		// us to sign in). The typed error carries the redirect target and any
+		// Retry-After so the caller can classify it and back off (see --rampup).
+		return nil, "", &CodeQueryStatusError{
+			Status:     res.StatusCode,
+			Location:   res.Header.Get("Location"),
+			RetryAfter: parseRetryAfter(res.Header),
+		}
 	}
 
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))
@@ -242,8 +246,9 @@ func (client *Bl3Client) resolveRedemption(res *HttpResponse) error {
 	for range 10 {
 		switch res.StatusCode {
 		case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+			ra := parseRetryAfter(res.Header)
 			_ = res.Body.Close()
-			return fmt.Errorf("%w (status %d)", ErrRateLimited, res.StatusCode)
+			return &RateLimitError{Status: res.StatusCode, RetryAfter: ra}
 		case 301, 302, 303:
 			location := res.Header.Get("Location")
 			_ = res.Body.Close()

--- a/shift.go
+++ b/shift.go
@@ -67,14 +67,14 @@ func parseCodeList(body []byte, dropExpired bool) []ShiftCode {
 	return codes
 }
 
-// GetShiftCodesV2 fetches and parses the newer ugoogalizer/mentalmars format,
-// filtering out codes flagged as expired.
+// GetShiftCodesV2 fetches and parses the newer ugoogalizer/mentalmars format.
+// Codes flagged as expired are filtered out unless AllowInactive is set.
 func (client *Bl3Client) GetShiftCodesV2() ([]ShiftCode, error) {
 	body, err := fetchBytes(client.Config.Shift.CodeListUrlV2)
 	if err != nil {
 		return nil, errors.New("failed to get v2 SHiFT code list: " + err.Error())
 	}
-	return parseCodeList(body, true), nil
+	return parseCodeList(body, !client.Config.Shift.AllowInactive), nil
 }
 
 // GetShiftCodesV1 fetches and parses the original orcicorn format. This format
@@ -155,7 +155,7 @@ func ServiceMatches(filter []string, service string) bool {
 // returns an empty slice and a human-readable reason (already redeemed, expired,
 // not available for this account, ...).
 func (client *Bl3Client) GetCodeRedemptionForms(code string) ([]RedemptionForm, string, error) {
-	token, err := client.getCsrfToken(client.Config.BaseUrl + "/code_redemptions/new")
+	token, err := client.redemptionToken()
 	if err != nil {
 		return nil, "", errors.New("failed to get redemption token (are you logged in?): " + err.Error())
 	}
@@ -271,7 +271,7 @@ func (client *Bl3Client) resolveRedemption(res *HttpResponse) error {
 // pollRedemptionStatus polls the async status endpoint until it reports a result
 // (or times out). The endpoint returns JSON with a "text" field once resolved.
 func (client *Bl3Client) pollRedemptionStatus(dataUrl string) error {
-	token, _ := client.getCsrfToken(client.Config.BaseUrl + "/code_redemptions/new")
+	token, _ := client.redemptionToken()
 	full := client.absoluteUrl(dataUrl)
 
 	for range 6 {

--- a/shift.go
+++ b/shift.go
@@ -179,8 +179,10 @@ func (client *Bl3Client) GetCodeRedemptionForms(code string) ([]RedemptionForm, 
 		return nil, "", fmt.Errorf("%w (status %d)", ErrRateLimited, res.StatusCode)
 	}
 	if res.StatusCode != 200 {
-		// A 5xx here generally means the code itself was rejected as invalid.
-		return nil, "", fmt.Errorf("code query returned status %d", res.StatusCode)
+		// A non-200 here is either an invalid code (e.g. 5xx) or, commonly, a 302
+		// redirect when SHiFT is soft rate-limiting / shadowbanning us. The typed
+		// error lets the caller count consecutive failures (see --rampup).
+		return nil, "", &CodeQueryStatusError{Status: res.StatusCode}
 	}
 
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))

--- a/shift.go
+++ b/shift.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -174,6 +175,9 @@ func (client *Bl3Client) GetCodeRedemptionForms(code string) ([]RedemptionForm, 
 	_ = res.Body.Close()
 	client.logf("GET %s?code=%s -> %d", client.Config.Shift.RedemptionInfoUrl, code, res.StatusCode)
 
+	if res.StatusCode == http.StatusTooManyRequests || res.StatusCode == http.StatusServiceUnavailable {
+		return nil, "", fmt.Errorf("%w (status %d)", ErrRateLimited, res.StatusCode)
+	}
 	if res.StatusCode != 200 {
 		// A 5xx here generally means the code itself was rejected as invalid.
 		return nil, "", fmt.Errorf("code query returned status %d", res.StatusCode)
@@ -235,6 +239,9 @@ func (client *Bl3Client) resolveRedemption(res *HttpResponse) error {
 
 	for range 10 {
 		switch res.StatusCode {
+		case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+			_ = res.Body.Close()
+			return fmt.Errorf("%w (status %d)", ErrRateLimited, res.StatusCode)
 		case 301, 302, 303:
 			location := res.Header.Get("Location")
 			_ = res.Body.Close()

--- a/shift.go
+++ b/shift.go
@@ -1,172 +1,330 @@
 package bl3auto
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 type ShiftConfig struct {
-	CodeListUrl   string `json:"codeListUrl"`
-	CodeInfoUrl   string `json:"codeInfoUrl"`
-	UserInfoUrl   string `json:"userInfoUrl"`
-	GameCodename  string `json:"gameCodename"`
-	AllowInactive bool
+	CodeListUrlV1     string `json:"codeListUrlV1"`
+	CodeListUrlV2     string `json:"codeListUrlV2"`
+	RedemptionInfoUrl string `json:"redemptionInfoUrl"`
+	RedemptionUrl     string `json:"redemptionUrl"`
+	AllowInactive     bool
 }
 
+// ShiftCode is a single code parsed from either code-list format.
+type ShiftCode struct {
+	Code     string `json:"code"`
+	Game     string `json:"game"`
+	Platform string `json:"platform"`
+	Reward   string `json:"reward"`
+	Expired  bool   `json:"expired"`
+}
+
+// ShiftCodeMap tracks which services a code has been redeemed on (the on-disk cache).
 type ShiftCodeMap map[string][]string
 
-func (codeMap ShiftCodeMap) Contains(code, platform string) bool {
-	platforms, found := codeMap[code]
+func (codeMap ShiftCodeMap) Contains(code, service string) bool {
+	services, found := codeMap[code]
 	if !found {
 		return false
 	}
-	return slices.Contains(platforms, platform)
+	return slices.Contains(services, service)
 }
 
-type shiftCode struct {
-	Game     string `json:"offer_title"`
-	Platform string `json:"offer_service"`
-	Active   bool   `json:"is_active"`
+// RedemptionForm is a single redeemable platform/service offered for a code,
+// along with the hidden form fields required to submit the redemption.
+type RedemptionForm struct {
+	Service string
+	Fields  map[string]string
 }
 
-type shiftCodeFromList struct {
-	Code     string `json:"code"`
-	Platform string `json:"platform"`
-}
+// parseCodeList parses either SHiFT code-list format. Both are a top-level array
+// whose first element holds a "codes" array. When dropExpired is set (the v2
+// format, which carries an "expired" flag) expired entries are filtered out.
+func parseCodeList(body []byte, dropExpired bool) []ShiftCode {
+	parsed := make([]ShiftCode, 0)
+	JsonFromBytes(body).From("[0].codes").
+		Select("code", "game", "platform", "reward", "expired").Out(&parsed)
 
-func (client *Bl3Client) GetCodePlatforms(code string) ([]string, bool) {
-	platforms := make([]string, 0)
-
-	res, err := client.Get(client.Config.Shift.CodeInfoUrl + code + "/info")
-	if err != nil {
-		return platforms, false
-	}
-
-	json, err := res.BodyAsJson()
-	if err != nil {
-		return platforms, false
-	}
-
-	codes := make([]shiftCode, 0)
-	json.From("entitlement_offer_codes").Select("offer_service", "is_active", "offer_title").Out(&codes)
-	for _, code := range codes {
-		//if (code.Active || client.Config.Shift.AllowInactive) && code.Game == client.Config.Shift.GameCodename {
-		platforms = append(platforms, code.Platform)
-		//}
-	}
-
-	if len(platforms) == 0 {
-		return platforms, false
-	}
-
-	return platforms, true
-}
-
-func (client *Bl3Client) RedeemShiftCode(code, platform string) error {
-	response, err := client.Post(client.Config.Shift.CodeInfoUrl+code+"/redeem/"+platform, "", nil)
-	if err != nil {
-		return errors.New("failed to initialize code redemption")
-	}
-
-	type redemptionJob struct {
-		JobId string `json:"job_id"`
-		Wait  int    `json:"max_wait_milliseconds"`
-	}
-
-	resJson, err := response.BodyAsJson()
-	if err != nil {
-		return errors.New("bad code init response")
-	}
-
-	redemptionInfo := redemptionJob{}
-	resJson.Out(&redemptionInfo)
-
-	if redemptionInfo.JobId == "" {
-		redemptionError := ""
-		resJson.Reset().From("error.code").Out(&redemptionError)
-		if redemptionError != "" {
-			return errors.New(strings.ToLower(strings.Join(strings.Split(redemptionError, "_"), " ")) + ". Try again later.")
+	codes := make([]ShiftCode, 0, len(parsed))
+	for _, c := range parsed {
+		if c.Code == "" || (dropExpired && c.Expired) {
+			continue
 		}
-		return errors.New("failed to schedule code redemption")
+		codes = append(codes, c)
 	}
-	// not sure if this is necessary
-	time.Sleep(time.Duration(redemptionInfo.Wait) * time.Millisecond)
-
-	redeemResponse, err := client.Get(client.Config.Shift.CodeInfoUrl + code + "/job/" + redemptionInfo.JobId)
-	if err != nil {
-		return errors.New("failed to initialize code redemption")
-	}
-
-	resJson, err = redeemResponse.BodyAsJson()
-	if err != nil {
-		return errors.New("bad code redemption response")
-	}
-
-	success := false
-	resJson.From("success").Out(&success)
-	errs := make([]string, 0)
-	resJson.Reset().From("errors").Out(&errs)
-	if len(errs) > 0 {
-		return errors.New(strings.ToLower(strings.Join(strings.Split(errs[0], "_"), " ")) + ".")
-	}
-	if !success {
-		return errors.New("failed to redeem SHiFT code")
-	}
-
-	resJson.Out(&redemptionInfo)
-
-	return nil
+	return codes
 }
 
-func (client *Bl3Client) GetShiftPlatforms() (StringSet, error) {
-	platforms := StringSet{}
-
-	response, err := client.Post(client.Config.Shift.UserInfoUrl, "", nil)
+// GetShiftCodesV2 fetches and parses the newer ugoogalizer/mentalmars format,
+// filtering out codes flagged as expired.
+func (client *Bl3Client) GetShiftCodesV2() ([]ShiftCode, error) {
+	body, err := fetchBytes(client.Config.Shift.CodeListUrlV2)
 	if err != nil {
-		return platforms, errors.New("failed to get available platforms list")
+		return nil, errors.New("failed to get v2 SHiFT code list: " + err.Error())
 	}
-
-	resJson, err := response.BodyAsJson()
-	if err != nil {
-		return platforms, err
-	}
-
-	platformList := make([]string, 0)
-	resJson.From("platforms").Out(&platformList)
-
-	for _, platform := range platformList {
-		platforms.Add(platform)
-	}
-	return platforms, nil
+	return parseCodeList(body, true), nil
 }
 
-func (client *Bl3Client) GetFullShiftCodeList() (ShiftCodeMap, error) {
-	codeMap := ShiftCodeMap{}
-	httpClient, err := NewHttpClient()
+// GetShiftCodesV1 fetches and parses the original orcicorn format. This format
+// has no "expired" flag, so all codes are returned (the SHiFT site rejects
+// stale ones at redemption time).
+func (client *Bl3Client) GetShiftCodesV1() ([]ShiftCode, error) {
+	body, err := fetchBytes(client.Config.Shift.CodeListUrlV1)
 	if err != nil {
-		return codeMap, err
+		return nil, errors.New("failed to get v1 SHiFT code list: " + err.Error())
 	}
+	return parseCodeList(body, false), nil
+}
 
-	res, err := httpClient.Get(client.Config.Shift.CodeListUrl)
-	if err != nil {
-		return codeMap, errors.New("failed to get SHiFT code list")
+// GetShiftCodes returns codes for the requested source. "v1"/"v2" force a single
+// source; any other value uses the default failover: try v2 first, fall back to
+// v1 if v2 errors or yields no codes. Results are de-duplicated by code.
+func (client *Bl3Client) GetShiftCodes(source string) ([]ShiftCode, error) {
+	switch source {
+	case "v1":
+		codes, err := client.GetShiftCodesV1()
+		return dedupeCodes(codes), err
+	case "v2":
+		codes, err := client.GetShiftCodesV2()
+		return dedupeCodes(codes), err
+	default:
+		codes, err := client.GetShiftCodesV2()
+		if err == nil && len(codes) > 0 {
+			return dedupeCodes(codes), nil
+		}
+		if err != nil {
+			client.logf("v2 code source failed (%v); falling back to v1", err)
+		} else {
+			client.logf("v2 code source returned no codes; falling back to v1")
+		}
+		v1, v1err := client.GetShiftCodesV1()
+		return dedupeCodes(v1), v1err
 	}
+}
 
-	json, err := res.BodyAsJson()
-	if err != nil {
-		return codeMap, errors.New("failed to get SHiFT code list body as JSON")
+func dedupeCodes(codes []ShiftCode) []ShiftCode {
+	seen := map[string]struct{}{}
+	out := make([]ShiftCode, 0, len(codes))
+	for _, c := range codes {
+		key := strings.ToUpper(strings.TrimSpace(c.Code))
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		c.Code = key
+		out = append(out, c)
 	}
+	return out
+}
 
-	codes := make([]shiftCodeFromList, 0)
-	json.From("[0].codes").Select("code", "platform").Out(&codes)
-	for _, code := range codes {
-		platforms, valid := client.GetCodePlatforms(code.Code)
-		if valid {
-			codeMap[code.Code] = platforms
+// ServiceMatches reports whether a service value should be redeemed given the
+// (possibly empty) platform filter. An empty filter matches everything; a
+// non-empty filter matches when any token is a substring of the service value
+// (e.g. filter "psn" matches service "psn" or "psn_..."), mirroring autoshift.
+func ServiceMatches(filter []string, service string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	service = strings.ToLower(service)
+	for _, f := range filter {
+		f = strings.ToLower(strings.TrimSpace(f))
+		if f != "" && strings.Contains(service, f) {
+			return true
 		}
 	}
+	return false
+}
 
-	return codeMap, nil
+// GetCodeRedemptionForms queries the SHiFT site for a code and returns one
+// RedemptionForm per available service. When no redeemable form is present it
+// returns an empty slice and a human-readable reason (already redeemed, expired,
+// not available for this account, ...).
+func (client *Bl3Client) GetCodeRedemptionForms(code string) ([]RedemptionForm, string, error) {
+	token, err := client.getCsrfToken(client.Config.BaseUrl + "/code_redemptions/new")
+	if err != nil {
+		return nil, "", errors.New("failed to get redemption token (are you logged in?): " + err.Error())
+	}
+
+	res, err := client.GetWithHeaders(
+		client.Config.Shift.RedemptionInfoUrl+"?code="+url.QueryEscape(code),
+		map[string]string{
+			"X-CSRF-Token":     token,
+			"X-Requested-With": "XMLHttpRequest",
+		},
+	)
+	if err != nil {
+		return nil, "", errors.New("failed to query code: " + err.Error())
+	}
+	bodyBytes, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	client.logf("GET %s?code=%s -> %d", client.Config.Shift.RedemptionInfoUrl, code, res.StatusCode)
+
+	if res.StatusCode != 200 {
+		// A 5xx here generally means the code itself was rejected as invalid.
+		return nil, "", fmt.Errorf("code query returned status %d", res.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, "", errors.New("failed to parse redemption page")
+	}
+
+	if doc.Find("form.new_archway_code_redemption").Length() == 0 {
+		// No form: the body text is the reason (an alert message).
+		return nil, strings.TrimSpace(doc.Text()), nil
+	}
+
+	forms := make([]RedemptionForm, 0)
+	doc.Find("form.new_archway_code_redemption").Each(func(_ int, form *goquery.Selection) {
+		service, ok := form.Find("input#archway_code_redemption_service").Attr("value")
+		if !ok || service == "" {
+			return
+		}
+		fields := map[string]string{}
+		form.Find("input").Each(func(_ int, inp *goquery.Selection) {
+			name, hasName := inp.Attr("name")
+			if !hasName || name == "" {
+				return
+			}
+			value, _ := inp.Attr("value")
+			fields[name] = value
+		})
+		forms = append(forms, RedemptionForm{Service: service, Fields: fields})
+	})
+
+	return forms, "", nil
+}
+
+// RedeemForm submits a single redemption form and resolves its outcome. It
+// returns nil on success; otherwise an error whose message indicates the reason
+// (contains "already" / "expired" / etc. so callers can classify it).
+func (client *Bl3Client) RedeemForm(form RedemptionForm) error {
+	data := url.Values{}
+	for k, v := range form.Fields {
+		data.Set(k, v)
+	}
+
+	res, err := client.PostForm(client.Config.Shift.RedemptionUrl, data, map[string]string{
+		"Referer": client.Config.Shift.RedemptionUrl + "/new",
+	})
+	if err != nil {
+		return errors.New("failed to submit redemption: " + err.Error())
+	}
+	return client.resolveRedemption(res)
+}
+
+// resolveRedemption follows the post-redemption redirect chain and reads the
+// final status (either a polled JSON status or an inline alert).
+func (client *Bl3Client) resolveRedemption(res *HttpResponse) error {
+	visitedRedemption := false
+
+	for range 10 {
+		switch res.StatusCode {
+		case 301, 302, 303:
+			location := res.Header.Get("Location")
+			_ = res.Body.Close()
+			if location == "" {
+				return errors.New("redemption redirected without a location")
+			}
+			if strings.Contains(location, "code_redemptions/") {
+				visitedRedemption = true
+			}
+			next, err := client.Get(client.absoluteUrl(location))
+			if err != nil {
+				return errors.New("failed to follow redemption redirect: " + err.Error())
+			}
+			res = next
+			continue
+		default:
+			bodyBytes, _ := io.ReadAll(res.Body)
+			_ = res.Body.Close()
+			doc, err := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))
+			if err != nil {
+				return errors.New("failed to parse redemption response")
+			}
+			if div := doc.Find("#check_redemption_status"); div.Length() > 0 {
+				if dataUrl, ok := div.Attr("data-url"); ok && dataUrl != "" {
+					return client.pollRedemptionStatus(dataUrl)
+				}
+			}
+			return statusFromText(doc.Find(".alert").Text(), visitedRedemption)
+		}
+	}
+	return errors.New("too many redemption redirects")
+}
+
+// pollRedemptionStatus polls the async status endpoint until it reports a result
+// (or times out). The endpoint returns JSON with a "text" field once resolved.
+func (client *Bl3Client) pollRedemptionStatus(dataUrl string) error {
+	token, _ := client.getCsrfToken(client.Config.BaseUrl + "/code_redemptions/new")
+	full := client.absoluteUrl(dataUrl)
+
+	for range 6 {
+		res, err := client.GetWithHeaders(full, map[string]string{
+			"X-CSRF-Token":     token,
+			"X-Requested-With": "XMLHttpRequest",
+			"Accept":           "application/json, text/javascript, */*; q=0.01",
+		})
+		if err != nil {
+			return errors.New("failed to check redemption status: " + err.Error())
+		}
+		body, _ := io.ReadAll(res.Body)
+		_ = res.Body.Close()
+
+		var payload struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(body, &payload) == nil && payload.Text != "" {
+			return statusFromText(payload.Text, true)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return errors.New("redemption still pending - launch a SHiFT-enabled title and try again later")
+}
+
+// statusFromText maps a SHiFT status/alert message to a result. nil means the
+// code was (or already was) redeemed successfully.
+func statusFromText(text string, visitedRedemption bool) error {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	switch {
+	case lower == "":
+		if visitedRedemption {
+			return nil
+		}
+		return errors.New("redemption returned no status; try again later")
+	case strings.Contains(lower, "success"):
+		return nil
+	case strings.Contains(lower, "already") && strings.Contains(lower, "redeem"):
+		return errors.New("this SHiFT code has already been redeemed")
+	case strings.Contains(lower, "expired"):
+		return errors.New("this SHiFT code has expired")
+	case strings.Contains(lower, "not available"):
+		return errors.New("this SHiFT code is not available for your account")
+	case strings.Contains(lower, "launch a shift"):
+		return errors.New("launch a SHiFT-enabled title first, then try again later")
+	default:
+		return errors.New(strings.TrimSpace(text))
+	}
+}
+
+func (client *Bl3Client) absoluteUrl(ref string) string {
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		return ref
+	}
+	return client.Config.BaseUrl + "/" + strings.TrimPrefix(ref, "/")
 }

--- a/shift_test.go
+++ b/shift_test.go
@@ -1,0 +1,99 @@
+package bl3auto
+
+import "testing"
+
+// v1 (orcicorn) fixture: top-level array, [0].codes, no "expired" field.
+const v1Fixture = `[
+  {
+    "meta": {"version": "1"},
+    "codes": [
+      {"code": "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE", "type": "shift", "game": "Borderlands 3", "platform": "Universal", "reward": "5 Golden Keys", "expires": "Unknown"},
+      {"code": "FFFFF-GGGGG-HHHHH-IIIII-JJJJJ", "type": "shift", "game": "Borderlands 2", "platform": "Steam", "reward": "3 Golden Keys", "expires": "Unknown"}
+    ]
+  }
+]`
+
+// v2 (ugoogalizer) fixture: same array shape but entries carry an "expired" flag.
+const v2Fixture = `[
+  {
+    "meta": {"version": "2"},
+    "codes": [
+      {"code": "BZFBT-WT9S3-WR3BC-3TJ3B-HSFBB", "type": "shift", "game": "Borderlands 4", "platform": "universal", "reward": "3 Golden Keys", "expired": false},
+      {"code": "OLD11-OLD22-OLD33-OLD44-OLD55", "type": "shift", "game": "Borderlands 4", "platform": "steam", "reward": "1 Golden Key", "expired": true},
+      {"code": "NEW11-NEW22-NEW33-NEW44-NEW55", "type": "shift", "game": "Borderlands 2", "platform": "epic", "reward": "10 Golden Keys", "expired": false}
+    ]
+  }
+]`
+
+func TestParseCodeListV1(t *testing.T) {
+	codes := parseCodeList([]byte(v1Fixture), false)
+	if len(codes) != 2 {
+		t.Fatalf("expected 2 codes, got %d", len(codes))
+	}
+	if codes[0].Code != "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE" || codes[0].Game != "Borderlands 3" {
+		t.Errorf("unexpected first code: %+v", codes[0])
+	}
+}
+
+func TestParseCodeListV2DropsExpired(t *testing.T) {
+	codes := parseCodeList([]byte(v2Fixture), true)
+	if len(codes) != 2 {
+		t.Fatalf("expected 2 non-expired codes, got %d", len(codes))
+	}
+	for _, c := range codes {
+		if c.Expired {
+			t.Errorf("expired code leaked through: %+v", c)
+		}
+	}
+	if codes[0].Game != "Borderlands 4" {
+		t.Errorf("expected Borderlands 4 first, got %q", codes[0].Game)
+	}
+}
+
+func TestDedupeCodes(t *testing.T) {
+	in := []ShiftCode{
+		{Code: "abcde-fghij-klmno-pqrst-uvwxy"},
+		{Code: "ABCDE-FGHIJ-KLMNO-PQRST-UVWXY"}, // same as above, different case
+		{Code: "  "},
+		{Code: "ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ"},
+	}
+	out := dedupeCodes(in)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 unique codes, got %d (%+v)", len(out), out)
+	}
+	if out[0].Code != "ABCDE-FGHIJ-KLMNO-PQRST-UVWXY" {
+		t.Errorf("expected normalized uppercase code, got %q", out[0].Code)
+	}
+}
+
+func TestServiceMatches(t *testing.T) {
+	cases := []struct {
+		filter  []string
+		service string
+		want    bool
+	}{
+		{nil, "steam", true},                      // empty filter matches all
+		{[]string{"steam"}, "steam", true},        // exact
+		{[]string{"psn"}, "psn_3", true},          // substring
+		{[]string{"PSN"}, "psn", true},            // case-insensitive
+		{[]string{"steam"}, "epic", false},        // no match
+		{[]string{"epic", "steam"}, "epic", true}, // one of many
+	}
+	for _, tc := range cases {
+		if got := ServiceMatches(tc.filter, tc.service); got != tc.want {
+			t.Errorf("ServiceMatches(%v, %q) = %v, want %v", tc.filter, tc.service, got, tc.want)
+		}
+	}
+}
+
+func TestStatusFromText(t *testing.T) {
+	if err := statusFromText("Your code was successfully redeemed", true); err != nil {
+		t.Errorf("success text should be nil, got %v", err)
+	}
+	if err := statusFromText("This SHiFT code has already been redeemed", false); err == nil {
+		t.Error("already-redeemed should be an error")
+	}
+	if err := statusFromText("This code has expired", false); err == nil {
+		t.Error("expired should be an error")
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -4,12 +4,6 @@ import (
 	"github.com/thedevsaddam/gojsonq/v2"
 )
 
-type StringSet map[string]struct{}
-
-func (set StringSet) Add(s string) {
-	set[s] = struct{}{}
-}
-
 func JsonFromString(s string) *gojsonq.JSONQ {
 	return gojsonq.New().JSONString(s)
 }

--- a/utils.go
+++ b/utils.go
@@ -19,11 +19,10 @@ func JsonFromBytes(bytes []byte) *gojsonq.JSONQ {
 }
 
 type Bl3Config struct {
-	Version             string            `json:"version"`
-	LoginUrl            string            `json:"loginUrl"`
-	LoginRedirectHeader string            `json:"loginRedirectHeader"`
-	SessionIdHeader     string            `json:"sessionIdHeader"`
-	RequestHeaders      map[string]string `json:"requestHeaders"`
-	SessionHeader       string            `json:"sessionHeader"`
-	Shift               ShiftConfig       `json:"shiftConfig"`
+	Version        string            `json:"version"`
+	BaseUrl        string            `json:"baseUrl"`
+	HomeUrl        string            `json:"homeUrl"`
+	LoginUrl       string            `json:"loginUrl"`
+	RequestHeaders map[string]string `json:"requestHeaders"`
+	Shift          ShiftConfig       `json:"shiftConfig"`
 }


### PR DESCRIPTION
## Why

GearBox retired the old `api.2k.com/borderlands/` login + redemption API that bl3auto relied on, breaking both authentication and code redemption. This migrates the entire flow to the Gearbox SHiFT website (`shift.gearboxsoftware.com`), following the approach proven by [Fabbi/autoshift](https://github.com/Fabbi/autoshift).

This supersedes #767, which fixed *login* but left redemption stubbed out (it returned "redeem manually" and hardcoded platform lists), reverted unrelated CI/dependency bumps, and switched to a local `config.json` read that breaks the Docker image (which copies only the binary). Here the login half of that PR is salvaged and the rest is reimplemented on top of current `main`.

## What changed

**Auth (`client.go`)**
- Login: `GET /home` → scrape CSRF token → `POST /sessions` → session cookie captured via the cookie jar.
- Fixed two bugs from the prior attempt: the manual `Accept-Encoding` header (broke Go's transparent gzip handling) and default headers clobbering per-request `Referer`/CSRF headers (defaults now only fill in what the caller hasn't set).
- Raw-JSON fetches (config + code lists on GitHub) use a redirect-following client; SHiFT requests block redirects so the 302s can be inspected.

**Redemption (`shift.go`)**
- `GET /entitlement_offer_codes?code=` → parse per-service redemption forms → `POST /code_redemptions` → poll `check_redemption_status` until the result resolves.

**Code sources (`shift.go`, `config.json`)**
- Dedicated `GetShiftCodesV1` / `GetShiftCodesV2` parsers. Default redemption uses v2 and falls back to v1 only if v2 is unavailable; `--v1`/`--v2` force a single source.
  - **v2** (default): [ugoogalizer/autoshift-codes](https://github.com/ugoogalizer/autoshift-codes) `shiftcodes.json` (includes **Borderlands 4**, filters out expired codes).
  - **v1**: [jauderho/shift-codes](https://github.com/jauderho/shift-codes) orcicorn `index.json`.

**CLI (`cmd/bl3auto.go`)**
- New flags: `--v1`, `--v2`, `--platform`, `--config`, `--dryrun`, `-v/--verbose`, plus a custom `--help` with examples.
- Borderlands 4 codes are handled automatically (v2 source + game-agnostic web redemption).

**Config**
- Still fetched from the published remote config by default (no behavior change for end users / Docker); `--config <path>` points at a local file for testing before the new URLs are merged.

## Tests

Adds `httptest`-based unit tests covering the client, auth (302/invalid/503/200 + cookie persistence), redemption (form parse, redirect→poll success, alert paths), code-list parsing + failover, and the `doShift` orchestration (dry-run, platform filter). Library logic is 75–100% per function (total 64.8%; remainder is `main`/`usage`/`exit` I/O glue).

`go build`, `go vet`, `go test` (24 pass), `gofmt`, and `go fix` (no changes) all clean.

## Verification

Tested end-to-end against the live SHiFT site: login succeeds (302 + session cookie), a Borderlands 4 code is discovered with steam/epic services, a **real redemption** completes via the status poll (`success!`), and the redeemed-codes cache is written and read back so re-runs skip already-redeemed entries.

## Reviewer notes

- Because config is fetched from `main` by default, the new GearBox URLs only take effect for end users once this is merged. Until then, local testing uses `--config ./config.json`.
- Embedding config via `go:embed` (for offline/Docker-without-network) is a possible follow-up; this PR keeps the existing remote-fetch mechanism.